### PR TITLE
feat: Add Firebase Analytics module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build
+
+```bash
+./GodotFirebaseiOS/build_and_copy.sh        # Debug
+./GodotFirebaseiOS/build_and_copy.sh r      # Release
+```
+
+Output framework is copied to `demo/addons/GodotFirebaseiOS/`. Requires macOS with Xcode 15+.
+
+## Run the Demo
+
+1. Place `GoogleService-Info.plist` in `demo/addons/GodotFirebaseiOS/`
+2. Open `demo/` in Godot 4.4+
+3. Export to a physical iOS device (required for Google Sign-In)
+
+## Architecture
+
+This plugin has a two-layer bridge: **Swift GDExtension → GDScript wrapper → game code**.
+
+**Layer 1 — Swift plugins** (`GodotFirebaseiOS/Sources/GodotFirebaseiOS/`): Each Firebase module is a `@Godot`-annotated `RefCounted` subclass with `@Callable` methods and `@Signal` definitions. These are compiled into a `.framework` and registered in `GodotFirebaseiOS.swift` via `#initSwiftExtension`. Async Firebase SDK calls use `Task { @MainActor in }` to ensure signals emit on the main thread.
+
+**Layer 2 — GDScript wrappers** (`demo/addons/GodotFirebaseiOS/modules/`): Thin wrappers (`Auth.gd`, `Firestore.gd`, etc.) that hold a reference to the Swift plugin object, forward all method calls with `if _plugin:` guards, and relay signals via `_connect_signals()`. These are composed into the `FirebaseIOS` autoload singleton (`FirebaseIOS.gd`), which instantiates each Swift class via `ClassDB.instantiate()` at runtime.
+
+**Export plugin** (`export_plugin.gd`): Runs at iOS export time to inject `REVERSED_CLIENT_ID` URL scheme into `Info.plist` and embed `GoogleService-Info.plist` into the app bundle.
+
+**Cross-platform stubs**: Non-iOS platforms use stub binaries (generated via `scripts/generate_stubs.sh`) so the Godot editor doesn't error when the native library isn't available.
+
+## Adding a New Firebase Module
+
+1. Create `Firebase<Name>Plugin.swift` — subclass `RefCounted`, use `@Godot`, `@Callable`, `@Signal` macros
+2. Register it in `GodotFirebaseiOS.swift`'s `#initSwiftExtension` types array
+3. Create `modules/<Name>.gd` — mirror signals, add `_connect_signals()`, forward methods with `if _plugin:` guards
+4. Wire it up in `FirebaseIOS.gd` following the existing pattern (ClassDB.class_exists → instantiate → assign to module)
+5. Update `GodotFirebaseiOS.gdextension` if needed
+
+## API Design Priority
+
+1. **Stay close to the official Firebase iOS SDK** — method names, parameters, and behavior should mirror the native Swift Firebase SDK as closely as possible within GDExtension constraints.
+2. **Match [GodotFirebaseAndroid](https://github.com/syntaxerror247/GodotFirebaseAndroid)** — as a secondary goal, keep the GDScript-facing API compatible so games can use the same interface on both platforms.
+
+## Testing
+
+No unit test suite. Validation is via the demo project scenes in `demo/scenes/`. All modules support Firebase Emulator Suite (`use_emulator()` methods). CI validates compilation only.
+
+## CI/CD
+
+- **build.yml** — PR validation on macOS-26
+- **release.yml** — Manual trigger: builds release, zips addon, creates GitHub Release
+- **docs.yml** — Auto-deploys Jekyll docs to GitHub Pages on push to main

--- a/GodotFirebaseiOS/Package.swift
+++ b/GodotFirebaseiOS/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
                 .product(name: "FirebaseAuth", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseFirestore", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseRemoteConfig", package: "firebase-ios-sdk"),
+                .product(name: "FirebaseAnalytics", package: "firebase-ios-sdk"),
                 .product(name: "GoogleSignIn", package: "GoogleSignIn-iOS")
             ],
             swiftSettings: [.unsafeFlags(["-suppress-warnings"])]

--- a/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseAnalyticsPlugin.swift
+++ b/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseAnalyticsPlugin.swift
@@ -57,10 +57,12 @@ class FirebaseAnalyticsPlugin: RefCounted, @unchecked Sendable {
     // MARK: - Consent
 
     @Callable
-    func set_consent(adStorage: Bool, analyticsStorage: Bool) {
+    func set_consent(adStorage: Bool, analyticsStorage: Bool, adUserData: Bool, adPersonalization: Bool) {
         Analytics.setConsent([
             .adStorage: adStorage ? .granted : .denied,
-            .analyticsStorage: analyticsStorage ? .granted : .denied
+            .analyticsStorage: analyticsStorage ? .granted : .denied,
+            .adUserData: adUserData ? .granted : .denied,
+            .adPersonalization: adPersonalization ? .granted : .denied
         ])
     }
 

--- a/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseAnalyticsPlugin.swift
+++ b/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseAnalyticsPlugin.swift
@@ -1,0 +1,98 @@
+@preconcurrency import SwiftGodotRuntime
+import FirebaseCore
+import FirebaseAnalytics
+
+@Godot
+class FirebaseAnalyticsPlugin: RefCounted, @unchecked Sendable {
+
+    // MARK: - Log Events
+
+    @Callable
+    func log_event(name: String, parameters: GDictionary) {
+        let swiftParams = gdDictToSwiftParams(parameters)
+        Analytics.logEvent(name, parameters: swiftParams.isEmpty ? nil : swiftParams)
+    }
+
+    // MARK: - User Properties
+
+    @Callable
+    func set_user_property(value: String, name: String) {
+        Analytics.setUserProperty(value, forName: name)
+    }
+
+    @Callable
+    func set_user_id(id: String) {
+        Analytics.setUserID(id.isEmpty ? nil : id)
+    }
+
+    // MARK: - Collection Control
+
+    @Callable
+    func set_analytics_collection_enabled(enabled: Bool) {
+        Analytics.setAnalyticsCollectionEnabled(enabled)
+    }
+
+    // MARK: - Default Event Parameters
+
+    @Callable
+    func set_default_event_parameters(parameters: GDictionary) {
+        let swiftParams = gdDictToSwiftParams(parameters)
+        Analytics.setDefaultEventParameters(swiftParams.isEmpty ? nil : swiftParams)
+    }
+
+    // MARK: - Reset
+
+    @Callable
+    func reset_analytics_data() {
+        Analytics.resetAnalyticsData()
+    }
+
+    // MARK: - App Instance ID
+
+    @Callable
+    func get_app_instance_id() -> String {
+        return Analytics.appInstanceID() ?? ""
+    }
+
+    // MARK: - Consent
+
+    @Callable
+    func set_consent(adStorage: Bool, analyticsStorage: Bool) {
+        Analytics.setConsent([
+            .adStorage: adStorage ? .granted : .denied,
+            .analyticsStorage: analyticsStorage ? .granted : .denied
+        ])
+    }
+
+    // MARK: - Session Timeout
+
+    @Callable
+    func set_session_timeout(seconds: Int) {
+        Analytics.setSessionTimeoutInterval(TimeInterval(seconds))
+    }
+
+    // MARK: - Helpers
+
+    private func gdDictToSwiftParams(_ gdDict: GDictionary) -> [String: Any] {
+        var result: [String: Any] = [:]
+        let keys = gdDict.keys()
+        for i in 0..<keys.size() {
+            let keyVariant = keys[Int(i)]
+            guard let keyStr = String(keyVariant) else { continue }
+            guard let value = gdDict[keyVariant] else { continue }
+            switch value.gtype {
+            case .bool:
+                result[keyStr] = Bool(value) ?? false
+            case .int:
+                result[keyStr] = Int(value) ?? 0
+            case .float:
+                result[keyStr] = Double(value) ?? 0.0
+            case .string:
+                result[keyStr] = String(value) ?? ""
+            default:
+                result[keyStr] = String(value) ?? ""
+            }
+        }
+        return result
+    }
+}

--- a/GodotFirebaseiOS/Sources/GodotFirebaseiOS/GodotFirebaseiOS.swift
+++ b/GodotFirebaseiOS/Sources/GodotFirebaseiOS/GodotFirebaseiOS.swift
@@ -6,7 +6,8 @@ import SwiftGodotRuntime
         FirebaseCorePlugin.self,
         FirebaseAuthPlugin.self,
         FirebaseFirestorePlugin.self,
-        FirebaseRemoteConfigPlugin.self
+        FirebaseRemoteConfigPlugin.self,
+        FirebaseAnalyticsPlugin.self
     ],
     registerDocs: false
 )

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Designed to work alongside [GodotFirebaseAndroid](https://github.com/syntaxerror
 - Real-time config update listener
 - Value source and fetch status introspection
 
+**Analytics**
+- Log custom and predefined events with parameters
+- User properties and user ID
+- Default event parameters
+- Consent management (ad and analytics storage)
+- Session timeout configuration
+
 ---
 
 ## Documentation

--- a/demo/addons/GodotFirebaseiOS/FirebaseIOS.gd
+++ b/demo/addons/GodotFirebaseiOS/FirebaseIOS.gd
@@ -6,6 +6,7 @@ signal firebase_error(message: String)
 var auth := preload("res://addons/GodotFirebaseiOS/modules/Auth.gd").new()
 var firestore := preload("res://addons/GodotFirebaseiOS/modules/Firestore.gd").new()
 var remote_config := preload("res://addons/GodotFirebaseiOS/modules/RemoteConfig.gd").new()
+var analytics := preload("res://addons/GodotFirebaseiOS/modules/Analytics.gd").new()
 
 func _ready() -> void:
 	if not OS.has_feature("ios"):
@@ -42,3 +43,9 @@ func _ready() -> void:
 		remote_config._plugin = _rc_plugin
 		remote_config._connect_signals()
 		remote_config.initialize()
+
+	# 5. Analytics module
+	if ClassDB.class_exists(&"FirebaseAnalyticsPlugin"):
+		var _analytics_plugin := ClassDB.instantiate(&"FirebaseAnalyticsPlugin")
+		analytics._plugin = _analytics_plugin
+		analytics._connect_signals()

--- a/demo/addons/GodotFirebaseiOS/modules/Analytics.gd
+++ b/demo/addons/GodotFirebaseiOS/modules/Analytics.gd
@@ -34,9 +34,9 @@ func get_app_instance_id() -> String:
 		return _plugin.get_app_instance_id()
 	return ""
 
-func set_consent(ad_storage: bool, analytics_storage: bool) -> void:
+func set_consent(ad_storage: bool, analytics_storage: bool, ad_user_data: bool = true, ad_personalization: bool = true) -> void:
 	if _plugin:
-		_plugin.set_consent(ad_storage, analytics_storage)
+		_plugin.set_consent(ad_storage, analytics_storage, ad_user_data, ad_personalization)
 
 func set_session_timeout(seconds: int) -> void:
 	if _plugin:

--- a/demo/addons/GodotFirebaseiOS/modules/Analytics.gd
+++ b/demo/addons/GodotFirebaseiOS/modules/Analytics.gd
@@ -1,0 +1,43 @@
+extends Node
+
+var _plugin: Object
+
+func _connect_signals():
+	pass
+
+func log_event(event_name: String, parameters: Dictionary = {}) -> void:
+	if _plugin:
+		_plugin.log_event(event_name, parameters)
+
+func set_user_property(value: String, name: String) -> void:
+	if _plugin:
+		_plugin.set_user_property(value, name)
+
+func set_user_id(id: String) -> void:
+	if _plugin:
+		_plugin.set_user_id(id)
+
+func set_analytics_collection_enabled(enabled: bool) -> void:
+	if _plugin:
+		_plugin.set_analytics_collection_enabled(enabled)
+
+func set_default_event_parameters(parameters: Dictionary) -> void:
+	if _plugin:
+		_plugin.set_default_event_parameters(parameters)
+
+func reset_analytics_data() -> void:
+	if _plugin:
+		_plugin.reset_analytics_data()
+
+func get_app_instance_id() -> String:
+	if _plugin:
+		return _plugin.get_app_instance_id()
+	return ""
+
+func set_consent(ad_storage: bool, analytics_storage: bool) -> void:
+	if _plugin:
+		_plugin.set_consent(ad_storage, analytics_storage)
+
+func set_session_timeout(seconds: int) -> void:
+	if _plugin:
+		_plugin.set_session_timeout(seconds)

--- a/demo/addons/GodotFirebaseiOS/modules/Analytics.gd.uid
+++ b/demo/addons/GodotFirebaseiOS/modules/Analytics.gd.uid
@@ -1,0 +1,1 @@
+uid://dcd8supyojixo

--- a/demo/main.gd
+++ b/demo/main.gd
@@ -3,6 +3,7 @@ extends Control
 var auth_scene = preload("res://scenes/authentication.tscn")
 var firestore_scene = preload("res://scenes/firestore.tscn")
 var remote_config_scene = preload("res://scenes/remote_config.tscn")
+var analytics_scene = preload("res://scenes/analytics.tscn")
 
 func _on_auth_pressed() -> void:
 	get_tree().change_scene_to_packed(auth_scene)
@@ -12,3 +13,6 @@ func _on_firestore_pressed() -> void:
 
 func _on_remote_config_pressed() -> void:
 	get_tree().change_scene_to_packed(remote_config_scene)
+
+func _on_analytics_pressed() -> void:
+	get_tree().change_scene_to_packed(analytics_scene)

--- a/demo/main.tscn
+++ b/demo/main.tscn
@@ -61,13 +61,15 @@ layout_mode = 2
 theme_override_font_sizes/font_size = 36
 text = "Remote Config"
 
-[node name="ComingSoon" type="Label" parent="MarginContainer/VBoxContainer" unique_id=793478508]
+[node name="AnalyticsButton" type="Button" parent="MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 80)
 layout_mode = 2
-theme_override_colors/font_color = Color(0.5, 0.5, 0.5, 1)
-theme_override_font_sizes/font_size = 24
-text = "More services coming soon..."
-horizontal_alignment = 1
+theme_override_font_sizes/font_size = 36
+text = "Analytics"
+
+[node name="ComingSoon" type="Label" parent="MarginContainer/VBoxContainer" unique_id=793478508]
 
 [connection signal="pressed" from="MarginContainer/VBoxContainer/AuthButton" to="." method="_on_auth_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/FirestoreButton" to="." method="_on_firestore_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/RemoteConfigButton" to="." method="_on_remote_config_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/AnalyticsButton" to="." method="_on_analytics_pressed"]

--- a/demo/main.tscn
+++ b/demo/main.tscn
@@ -68,6 +68,7 @@ theme_override_font_sizes/font_size = 36
 text = "Analytics"
 
 [node name="ComingSoon" type="Label" parent="MarginContainer/VBoxContainer" unique_id=793478508]
+text = "More services coming soon..."
 
 [connection signal="pressed" from="MarginContainer/VBoxContainer/AuthButton" to="." method="_on_auth_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/FirestoreButton" to="." method="_on_firestore_pressed"]

--- a/demo/scenes/analytics.gd
+++ b/demo/scenes/analytics.gd
@@ -1,0 +1,81 @@
+extends Control
+
+@onready var output: RichTextLabel = %OutputPanel
+
+var _collection_enabled := true
+
+func _ready() -> void:
+	_log("platform", "iOS")
+
+# --- Actions ---
+
+func _on_log_event_pressed() -> void:
+	_log("action", "Logging custom event 'test_event'...")
+	FirebaseIOS.analytics.log_event("test_event", {
+		"item_name": "sword_of_fire",
+		"item_category": "weapons",
+		"value": 100
+	})
+	_log("done", "Event logged (check Firebase Console)")
+
+func _on_log_purchase_pressed() -> void:
+	_log("action", "Logging purchase event...")
+	FirebaseIOS.analytics.log_event("purchase", {
+		"currency": "USD",
+		"value": 9.99,
+		"item_id": "gem_pack_100"
+	})
+	_log("done", "Purchase event logged")
+
+func _on_set_user_id_pressed() -> void:
+	_log("action", "Setting user ID to 'test_user_123'...")
+	FirebaseIOS.analytics.set_user_id("test_user_123")
+	_log("done", "User ID set")
+
+func _on_set_user_property_pressed() -> void:
+	_log("action", "Setting user property 'favorite_food' = 'pizza'...")
+	FirebaseIOS.analytics.set_user_property("pizza", "favorite_food")
+	_log("done", "User property set")
+
+func _on_set_default_params_pressed() -> void:
+	_log("action", "Setting default event parameters...")
+	FirebaseIOS.analytics.set_default_event_parameters({
+		"app_version": "1.0.0",
+		"platform": "ios"
+	})
+	_log("done", "Default parameters set")
+
+func _on_get_instance_id_pressed() -> void:
+	var instance_id = FirebaseIOS.analytics.get_app_instance_id()
+	_log("instance_id", instance_id if instance_id else "(empty)")
+
+func _on_reset_analytics_pressed() -> void:
+	_log("action", "Resetting analytics data...")
+	FirebaseIOS.analytics.reset_analytics_data()
+	_log("done", "Analytics data reset")
+
+func _on_toggle_collection_pressed() -> void:
+	_collection_enabled = not _collection_enabled
+	_log("action", "Setting analytics collection to %s..." % str(_collection_enabled))
+	FirebaseIOS.analytics.set_analytics_collection_enabled(_collection_enabled)
+	_log("done", "Collection %s" % ("enabled" if _collection_enabled else "disabled"))
+
+# --- Logging ---
+
+func _log(context: String, message: String) -> void:
+	var t = Time.get_time_string_from_system()
+	output.text += "[%s] %s: %s\n" % [t, context, message]
+	if not is_inside_tree():
+		return
+	await get_tree().process_frame
+	if not is_inside_tree():
+		return
+	output.scroll_to_line(output.get_line_count())
+
+# --- Navigation ---
+
+func _on_back_pressed() -> void:
+	get_tree().change_scene_to_packed(load("res://main.tscn"))
+
+func _on_clear_output_pressed() -> void:
+	output.text = ""

--- a/demo/scenes/analytics.gd.uid
+++ b/demo/scenes/analytics.gd.uid
@@ -1,0 +1,1 @@
+uid://cpaiw4vldb0fv

--- a/demo/scenes/analytics.tscn
+++ b/demo/scenes/analytics.tscn
@@ -1,0 +1,134 @@
+[gd_scene load_steps=2 format=3 uid="uid://danalytics_scene"]
+
+[ext_resource type="Script" path="res://scenes/analytics.gd" id="1_analytics"]
+
+[node name="Analytics" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_analytics")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.133, 0.133, 0.133, 1)
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 40
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 40
+theme_override_constants/margin_bottom = 20
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="BackButton" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 50)
+theme_override_font_sizes/font_size = 28
+text = "< Back"
+
+[node name="TitleLabel" type="Label" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Analytics"
+horizontal_alignment = 1
+
+[node name="HSeparator1" type="HSeparator" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="LogEvent" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 50)
+theme_override_font_sizes/font_size = 24
+text = "Log Custom Event"
+
+[node name="LogPurchase" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 50)
+theme_override_font_sizes/font_size = 24
+text = "Log Purchase Event"
+
+[node name="HSeparator2" type="HSeparator" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="SetUserId" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 50)
+theme_override_font_sizes/font_size = 24
+text = "Set User ID"
+
+[node name="SetUserProperty" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 50)
+theme_override_font_sizes/font_size = 24
+text = "Set User Property"
+
+[node name="SetDefaultParams" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 50)
+theme_override_font_sizes/font_size = 24
+text = "Set Default Params"
+
+[node name="HSeparator3" type="HSeparator" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="GetInstanceId" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 50)
+theme_override_font_sizes/font_size = 24
+text = "Get Instance ID"
+
+[node name="ResetAnalytics" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 50)
+theme_override_font_sizes/font_size = 24
+text = "Reset Analytics"
+
+[node name="ToggleCollection" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 50)
+theme_override_font_sizes/font_size = 24
+text = "Toggle Collection"
+
+[node name="HSeparator4" type="HSeparator" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="ClearOutput" type="Button" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 40)
+theme_override_font_sizes/font_size = 22
+text = "Clear Output"
+
+[node name="OutputPanel" type="RichTextLabel" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_font_sizes/normal_font_size = 20
+text = ""
+scroll_following = true
+
+[connection signal="pressed" from="MarginContainer/VBoxContainer/BackButton" to="." method="_on_back_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/LogEvent" to="." method="_on_log_event_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/LogPurchase" to="." method="_on_log_purchase_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/SetUserId" to="." method="_on_set_user_id_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/SetUserProperty" to="." method="_on_set_user_property_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/SetDefaultParams" to="." method="_on_set_default_params_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/GetInstanceId" to="." method="_on_get_instance_id_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ResetAnalytics" to="." method="_on_reset_analytics_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ToggleCollection" to="." method="_on_toggle_collection_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ClearOutput" to="." method="_on_clear_output_pressed"]

--- a/demo/scenes/analytics.tscn
+++ b/demo/scenes/analytics.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://danalytics_scene"]
+[gd_scene load_steps=3 format=3 uid="uid://danalytics_scene"]
 
 [ext_resource type="Script" path="res://scenes/analytics.gd" id="1_analytics"]
+[ext_resource type="Script" uid="uid://dob7x2ghdnqc8" path="res://scenes/safe_area_container.gd" id="2_safearea"]
 
 [node name="Analytics" type="Control"]
 layout_mode = 3
@@ -36,9 +37,13 @@ theme_override_constants/margin_bottom = 20
 layout_mode = 2
 theme_override_constants/separation = 8
 
-[node name="BackButton" type="Button" parent="MarginContainer/VBoxContainer"]
+[node name="SafeAreaContainer" type="MarginContainer" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
+script = ExtResource("2_safearea")
+
+[node name="BackButton" type="Button" parent="MarginContainer/VBoxContainer/SafeAreaContainer"]
 custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
 theme_override_font_sizes/font_size = 28
 text = "< Back"
 
@@ -122,7 +127,7 @@ theme_override_font_sizes/normal_font_size = 20
 text = ""
 scroll_following = true
 
-[connection signal="pressed" from="MarginContainer/VBoxContainer/BackButton" to="." method="_on_back_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/SafeAreaContainer/BackButton" to="." method="_on_back_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/LogEvent" to="." method="_on_log_event_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/LogPurchase" to="." method="_on_log_purchase_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/SetUserId" to="." method="_on_set_user_id_pressed"]

--- a/docs/analytics-consent.md
+++ b/docs/analytics-consent.md
@@ -1,0 +1,202 @@
+---
+title: Analytics Consent
+nav_order: 6
+layout: default
+---
+
+# Analytics Consent Guide
+
+How to handle user privacy consent for Firebase Analytics in your Godot iOS game.
+
+> **Official Firebase docs:** [Consent mode](https://firebase.google.com/docs/analytics/configure-data-collection-consent) · [Apple privacy requirements](https://support.google.com/firebase/answer/9976903)
+
+## Overview
+
+Privacy regulations like **GDPR** (Europe), **DMA** (Digital Markets Act), and **US state privacy laws** (CCPA, etc.) require you to obtain user consent before collecting certain types of data. Firebase Analytics provides a consent API that controls what data is collected and sent to Google.
+
+This plugin exposes Firebase's consent API through `set_consent()`, giving you full control over consent state.
+
+## Consent Types
+
+Firebase defines four consent types:
+
+| Parameter | Controls | Default |
+|:--|:--|:--|
+| `ad_storage` | Storage (cookies, device identifiers) related to advertising | `granted` |
+| `analytics_storage` | Storage related to analytics (e.g., visit duration, app identifiers) | `granted` |
+| `ad_user_data` | Sending user data to Google for advertising purposes | `granted` |
+| `ad_personalization` | Personalized advertising (remarketing) | `granted` |
+
+All consent types default to `granted`. You should call `set_consent()` **before** logging any events if your users have not yet consented.
+
+## When Do You Need This?
+
+**You need consent management if:**
+- Your game is available in the EU/EEA (GDPR, DMA)
+- Your game is available in US states with privacy laws (California, Colorado, Connecticut, etc.)
+- You show ads via AdMob or other ad networks
+- You collect or share user data with third parties
+
+**You probably don't need it if:**
+- Your game is only available in regions without privacy regulations
+- You've disabled analytics collection entirely
+
+## Basic Usage
+
+```gdscript
+# At app startup, before logging any events, set consent based on user choice.
+# Denied by default until the user consents:
+FirebaseIOS.analytics.set_consent(false, false, false, false)
+
+# After the user grants consent:
+FirebaseIOS.analytics.set_consent(true, true, true, true)
+```
+
+## Implementation Pattern
+
+A typical flow for handling consent in a Godot game:
+
+```gdscript
+extends Node
+
+# Call this at game startup
+func _ready() -> void:
+    var consent = _load_consent()
+    if consent.is_empty():
+        # First launch — deny all until user decides
+        FirebaseIOS.analytics.set_consent(false, false, false, false)
+        _show_consent_dialog()
+    else:
+        # Returning user — apply saved preferences
+        FirebaseIOS.analytics.set_consent(
+            consent.get("ad_storage", false),
+            consent.get("analytics_storage", false),
+            consent.get("ad_user_data", false),
+            consent.get("ad_personalization", false)
+        )
+
+func _on_consent_accepted() -> void:
+    # User accepted all
+    FirebaseIOS.analytics.set_consent(true, true, true, true)
+    _save_consent({
+        "ad_storage": true,
+        "analytics_storage": true,
+        "ad_user_data": true,
+        "ad_personalization": true
+    })
+
+func _on_consent_declined() -> void:
+    # User declined — analytics only (no ad data)
+    FirebaseIOS.analytics.set_consent(false, true, false, false)
+    _save_consent({
+        "ad_storage": false,
+        "analytics_storage": true,
+        "ad_user_data": false,
+        "ad_personalization": false
+    })
+
+func _on_consent_minimal() -> void:
+    # User wants minimum data collection
+    FirebaseIOS.analytics.set_consent(false, false, false, false)
+    _save_consent({
+        "ad_storage": false,
+        "analytics_storage": false,
+        "ad_user_data": false,
+        "ad_personalization": false
+    })
+
+# --- Persistence ---
+
+const CONSENT_PATH = "user://consent.cfg"
+
+func _save_consent(consent: Dictionary) -> void:
+    var config = ConfigFile.new()
+    for key in consent:
+        config.set_value("consent", key, consent[key])
+    config.save(CONSENT_PATH)
+
+func _load_consent() -> Dictionary:
+    var config = ConfigFile.new()
+    if config.load(CONSENT_PATH) != OK:
+        return {}
+    var consent := {}
+    for key in config.get_section_keys("consent"):
+        consent[key] = config.get_value("consent", key)
+    return consent
+
+func _show_consent_dialog() -> void:
+    # Show your custom consent UI here
+    pass
+```
+
+## What Happens When Consent Is Denied?
+
+When consent is denied, Firebase Analytics adjusts its behavior:
+
+| Consent denied | Effect |
+|:--|:--|
+| `analytics_storage` | No analytics cookies/identifiers stored. Events are sent without identifiers (cookieless pings). |
+| `ad_storage` | No advertising cookies/identifiers stored. |
+| `ad_user_data` | User data is not sent to Google for advertising. |
+| `ad_personalization` | No remarketing or personalized ads. |
+
+Firebase still sends **cookieless pings** (without user identifiers) even when consent is denied, so you retain basic measurement data like event counts.
+
+## Using with AdMob
+
+If you also use [Godot AdMob Plugin](https://github.com/poingstudios/godot-admob-plugin), be aware that:
+
+- **AdMob's UMP (User Messaging Platform)** handles consent dialogs and automatically updates Google's Consent Mode for all Firebase products, including Analytics.
+- If UMP is managing consent, **do not** also call `set_consent()` — let UMP handle it to avoid conflicts.
+- If you are **not** using AdMob/UMP, use `set_consent()` with your own consent UI.
+
+| Setup | Who manages consent |
+|:--|:--|
+| Analytics only (this plugin) | You — call `set_consent()` based on your own UI |
+| Analytics + AdMob with UMP | AdMob UMP — it updates consent for all Firebase SDKs automatically |
+| Analytics + AdMob without UMP | You — call `set_consent()` based on your own UI |
+
+## Apple ATT (App Tracking Transparency)
+
+Apple's **ATT framework** is separate from Firebase Consent Mode:
+
+- **ATT** controls access to the **IDFA** (Identifier for Advertisers) at the OS level. It's required by Apple before any cross-app tracking.
+- **Consent Mode** controls what data Firebase/Google collects and processes.
+
+They operate independently — you may need both if you use ad tracking. ATT is typically handled by the ad SDK (e.g., AdMob plugin), not by this analytics plugin.
+
+## Recommended Consent Configurations
+
+```gdscript
+# Full consent — user agreed to everything
+FirebaseIOS.analytics.set_consent(true, true, true, true)
+
+# Analytics only — no ad-related data sharing (common for games without ads)
+FirebaseIOS.analytics.set_consent(false, true, false, false)
+
+# No consent — minimum data collection
+FirebaseIOS.analytics.set_consent(false, false, false, false)
+
+# Ads allowed but no personalization
+FirebaseIOS.analytics.set_consent(true, true, true, false)
+```
+
+## Letting Users Change Their Mind
+
+GDPR requires that users can **withdraw consent** at any time. Add a settings option:
+
+```gdscript
+func _on_privacy_settings_pressed() -> void:
+    _show_consent_dialog()  # Re-show your consent UI
+
+func _on_consent_updated(new_consent: Dictionary) -> void:
+    FirebaseIOS.analytics.set_consent(
+        new_consent.get("ad_storage", false),
+        new_consent.get("analytics_storage", false),
+        new_consent.get("ad_user_data", false),
+        new_consent.get("ad_personalization", false)
+    )
+    _save_consent(new_consent)
+```
+
+Consent changes take effect immediately — Firebase adjusts data collection without requiring a restart.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -116,15 +116,18 @@ if instance_id != "":
 ---
 
 {: .text-green-100 }
-### set_consent(ad_storage: bool, analytics_storage: bool)
+### set_consent(ad_storage: bool, analytics_storage: bool, ad_user_data: bool = true, ad_personalization: bool = true)
 
-Manages analytics consent for ad and analytics storage. Use this to comply with privacy regulations.
+Manages analytics consent for ad storage, analytics storage, ad user data, and ad personalization. Use this to comply with privacy regulations like GDPR and DMA.
 
 ```gdscript
 # User granted full consent
-FirebaseIOS.analytics.set_consent(true, true)
+FirebaseIOS.analytics.set_consent(true, true, true, true)
 
 # User denied ad tracking but allowed analytics
+FirebaseIOS.analytics.set_consent(false, true, false, false)
+
+# Minimal — only analytics, no ad-related consent
 FirebaseIOS.analytics.set_consent(false, true)
 ```
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -145,6 +145,28 @@ FirebaseIOS.analytics.set_session_timeout(600)
 
 ---
 
+## Debug Mode
+
+Firebase Analytics batches events and sends them roughly every hour. To see events in **real-time** during development, enable DebugView:
+
+1. Export your Godot project to iOS
+2. Open the generated `.xcodeproj` in Xcode
+3. Go to **Product → Scheme → Edit Scheme** (or `Cmd+<`)
+4. Select **Run → Arguments**
+5. Under **Arguments Passed On Launch**, add:
+   ```
+   -FIRDebugEnabled
+   ```
+6. Run on a physical iOS device
+
+Then open **Firebase Console → Analytics → DebugView** to see events arriving in real-time as you interact with your app.
+
+To disable debug mode later, remove the argument or replace it with `-FIRDebugDisabled`.
+
+> **Note:** This launch argument is set on the **exported Xcode project**, not during the plugin build. It is a runtime flag that tells the Firebase SDK to send events immediately.
+
+---
+
 ## Example Usage
 
 ```gdscript

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -8,6 +8,8 @@ layout: default
 
 Firebase Analytics for iOS via the `FirebaseIOS.analytics` autoload.
 
+> **Official Firebase docs:** [Firebase Analytics](https://firebase.google.com/docs/analytics) · [Get started (iOS)](https://firebase.google.com/docs/analytics/ios/get-started)
+
 Note that Analytics has no signals — all methods are fire-and-forget.
 
 ## Methods

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,177 @@
+---
+title: Analytics
+nav_order: 5
+layout: default
+---
+
+# Analytics
+
+Firebase Analytics for iOS via the `FirebaseIOS.analytics` autoload.
+
+Note that Analytics has no signals — all methods are fire-and-forget.
+
+## Methods
+
+{: .text-green-100 }
+### log_event(event_name: String, parameters: Dictionary = {})
+
+Logs an analytics event with optional parameters. Use predefined event names like `"login"`, `"purchase"`, `"level_up"` for best results in the Firebase console.
+
+```gdscript
+# Simple event
+FirebaseIOS.analytics.log_event("tutorial_complete")
+
+# Event with parameters
+FirebaseIOS.analytics.log_event("purchase", {
+    "item_id": "sword_01",
+    "item_name": "Iron Sword",
+    "value": 4.99
+})
+
+# Predefined events
+FirebaseIOS.analytics.log_event("login", {"method": "google"})
+FirebaseIOS.analytics.log_event("level_up", {"level": 5, "character": "warrior"})
+```
+
+---
+
+{: .text-green-100 }
+### set_user_property(value: String, name: String)
+
+Sets a user property for analytics segmentation. User properties are attributes you define to describe segments of your user base.
+
+```gdscript
+FirebaseIOS.analytics.set_user_property("premium", "membership_tier")
+```
+
+---
+
+{: .text-green-100 }
+### set_user_id(id: String)
+
+Sets the user ID for analytics. Pass an empty string to clear the user ID.
+
+```gdscript
+FirebaseIOS.analytics.set_user_id("player_12345")
+
+# Clear the user ID
+FirebaseIOS.analytics.set_user_id("")
+```
+
+---
+
+{: .text-green-100 }
+### set_analytics_collection_enabled(enabled: bool)
+
+Enables or disables analytics collection. When disabled, no events are logged or sent to Firebase.
+
+```gdscript
+# Disable collection (e.g., user opted out)
+FirebaseIOS.analytics.set_analytics_collection_enabled(false)
+
+# Re-enable collection
+FirebaseIOS.analytics.set_analytics_collection_enabled(true)
+```
+
+---
+
+{: .text-green-100 }
+### set_default_event_parameters(parameters: Dictionary)
+
+Sets parameters that are sent with every subsequent event. Useful for global context like app version or player segment.
+
+```gdscript
+FirebaseIOS.analytics.set_default_event_parameters({
+    "app_version": "1.2.0",
+    "player_segment": "returning"
+})
+```
+
+---
+
+{: .text-green-100 }
+### reset_analytics_data()
+
+Clears all analytics data for this app instance. This resets the app instance ID and any stored user properties.
+
+```gdscript
+FirebaseIOS.analytics.reset_analytics_data()
+```
+
+---
+
+{: .text-green-100 }
+### get_app_instance_id() -> String
+
+Returns the app instance ID. Returns an empty string if analytics has not been initialized or the ID is not yet available.
+
+```gdscript
+var instance_id = FirebaseIOS.analytics.get_app_instance_id()
+if instance_id != "":
+    print("App Instance ID: %s" % instance_id)
+```
+
+---
+
+{: .text-green-100 }
+### set_consent(ad_storage: bool, analytics_storage: bool)
+
+Manages analytics consent for ad and analytics storage. Use this to comply with privacy regulations.
+
+```gdscript
+# User granted full consent
+FirebaseIOS.analytics.set_consent(true, true)
+
+# User denied ad tracking but allowed analytics
+FirebaseIOS.analytics.set_consent(false, true)
+```
+
+---
+
+{: .text-green-100 }
+### set_session_timeout(seconds: int)
+
+Sets the session timeout duration in seconds. Default is 1800 (30 minutes). A new session begins when the app is foregrounded after exceeding this timeout.
+
+```gdscript
+# Set timeout to 10 minutes
+FirebaseIOS.analytics.set_session_timeout(600)
+```
+
+---
+
+## Example Usage
+
+```gdscript
+func _ready() -> void:
+    # Set up analytics defaults
+    FirebaseIOS.analytics.set_default_event_parameters({
+        "app_version": "1.0.0",
+        "build": "release"
+    })
+
+    # Set user ID after authentication
+    var user = FirebaseIOS.auth.get_current_user_data()
+    if user.has("uid"):
+        FirebaseIOS.analytics.set_user_id(user["uid"])
+
+    # Set user properties for segmentation
+    FirebaseIOS.analytics.set_user_property("free", "account_type")
+
+    # Log game start
+    FirebaseIOS.analytics.log_event("game_start")
+
+func _on_level_completed(level: int, score: int) -> void:
+    FirebaseIOS.analytics.log_event("level_complete", {
+        "level_number": level,
+        "score": score,
+        "time_spent": elapsed_time
+    })
+
+func _on_purchase_completed(item_id: String, price: float) -> void:
+    FirebaseIOS.analytics.log_event("purchase", {
+        "item_id": item_id,
+        "value": price,
+        "currency": "USD"
+    })
+```

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -147,6 +147,8 @@ FirebaseIOS.analytics.set_session_timeout(600)
 
 ## Debug Mode
 
+> **Official Firebase docs:** [DebugView](https://firebase.google.com/docs/analytics/debugview)
+
 Firebase Analytics batches events and sends them roughly every hour. To see events in **real-time** during development, enable DebugView:
 
 1. Export your Godot project to iOS

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -8,6 +8,8 @@ layout: default
 
 Firebase Authentication for iOS via the `FirebaseIOS.auth` autoload.
 
+> **Official Firebase docs:** [Firebase Authentication](https://firebase.google.com/docs/auth) · [Get started (iOS)](https://firebase.google.com/docs/auth/ios/start)
+
 ## Signals
 
 - `auth_success(current_user_data: Dictionary)`

--- a/docs/core.md
+++ b/docs/core.md
@@ -16,6 +16,7 @@ When the plugin is enabled, the `FirebaseIOS` autoload runs this sequence in `_r
 2. **Auth** — `FirebaseAuthPlugin` is instantiated and its signals are connected
 3. **Firestore** — `FirebaseFirestorePlugin` is instantiated, signals are connected, and Firestore is initialized
 4. **Remote Config** — `FirebaseRemoteConfigPlugin` is instantiated and its signals are connected
+5. **Analytics** — `FirebaseAnalyticsPlugin` is instantiated (fire-and-forget, no signals)
 
 All of this happens automatically. You do not need to call `initialize()` yourself.
 
@@ -54,7 +55,8 @@ FirebaseIOS (Autoload)
 ├── core          → FirebaseCorePlugin          (FirebaseApp.configure)
 ├── auth          → FirebaseAuthPlugin          (Authentication)
 ├── firestore     → FirebaseFirestorePlugin     (Cloud Firestore)
-└── remote_config → FirebaseRemoteConfigPlugin  (Remote Config)
+├── remote_config → FirebaseRemoteConfigPlugin  (Remote Config)
+└── analytics     → FirebaseAnalyticsPlugin     (Analytics)
 ```
 
 Each service plugin is independent — Auth and Firestore are peers, neither depends on the other. They only require that Core has initialized Firebase first, which the autoload guarantees.

--- a/docs/cross-platform-wrapper.md
+++ b/docs/cross-platform-wrapper.md
@@ -15,7 +15,7 @@ This avoids duplicating logic in your game scenes — they just call `FirebaseWr
 - [GodotFirebaseiOS](https://github.com/SomniGameStudios/godot-firebase-ios) — iOS plugin
 - [GodotFirebaseAndroid](https://github.com/syntaxerror247/GodotFirebaseAndroid) — Android plugin
 
-Both plugins expose a consistent API with the same signals and method names for Auth, Firestore, and Remote Config, so the wrapper is thin.
+Both plugins expose a consistent API with the same signals and method names for Auth, Firestore, Remote Config, and Analytics, so the wrapper is thin.
 
 ## FirebaseWrapper Autoload
 
@@ -61,6 +61,15 @@ var remote_config:
                 return Firebase.remote_config
         return null
 
+var analytics:
+    get:
+        match _platform:
+            Platform.IOS:
+                return FirebaseIOS.analytics
+            Platform.ANDROID:
+                return Firebase.analytics
+        return null
+
 func _ready() -> void:
     if ClassDB.class_exists(&"FirebaseCorePlugin"):
         _platform = Platform.IOS
@@ -101,5 +110,5 @@ func _on_get_document_pressed() -> void:
 
 - Both `FirebaseIOS` and `Firebase` (Android) autoloads must be enabled in your project.
 - Apple Sign-In is iOS only.
-- Remote Config APIs are consistent across both platforms.
+- Analytics and Remote Config APIs are consistent across both platforms.
 - Each plugin is maintained independently — check their repos for the latest API.

--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -8,6 +8,8 @@ layout: default
 
 Cloud Firestore for iOS via the `FirebaseIOS.firestore` autoload.
 
+> **Official Firebase docs:** [Cloud Firestore](https://firebase.google.com/docs/firestore) · [Get started (iOS)](https://firebase.google.com/docs/firestore/ios/get-started)
+
 ## Signals
 
 All task signals emit a single `result: Dictionary` with the following keys:

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ Designed to work alongside [GodotFirebaseAndroid](https://github.com/syntaxerror
 - Authentication (Anonymous, Google, Apple, account linking)
 - Cloud Firestore (CRUD, real-time listeners)
 - Remote Config (fetch, activate, typed getters, real-time updates)
+- Analytics (events, user properties, consent, session management)
 
 ## Setup
 

--- a/docs/remote-config.md
+++ b/docs/remote-config.md
@@ -8,6 +8,8 @@ layout: default
 
 Firebase Remote Config for iOS via the `FirebaseIOS.remote_config` autoload.
 
+> **Official Firebase docs:** [Firebase Remote Config](https://firebase.google.com/docs/remote-config) · [Get started (iOS)](https://firebase.google.com/docs/remote-config/ios/get-started)
+
 ## Signals
 
 - `fetch_completed(result: Dictionary)`


### PR DESCRIPTION
## Summary

- New **Analytics** module: Swift plugin (`FirebaseAnalyticsPlugin`), GDScript wrapper, demo scene, and full documentation
- Event logging with custom parameters, user properties, user ID, default event parameters
- Full consent management with all 4 Firebase consent types: ad storage, analytics storage, ad user data, and ad personalization (GDPR/DMA compliant)
- Session timeout configuration, analytics data reset, and app instance ID retrieval
- **Analytics Consent guide** — dedicated docs page covering GDPR/DMA compliance, consent implementation patterns, AdMob/UMP interop, and Apple ATT
- Official Firebase documentation links added to all module doc pages
- Updates to main menu, cross-platform wrapper, core docs, README, and index to include Analytics

> **Note:** This PR targets `feature/sdk-parity` — merge that first, then this one into `main`.

## Test plan

- [x] Build the Swift package in Xcode to verify FirebaseAnalytics dependency resolves
- [x] Run the demo on an iOS device with `-FIRAnalyticsDebugEnabled` launch argument
- [x] Test: log custom event, log purchase event, set user ID, set user property
- [x] Test: set default params, reset analytics, get instance ID, toggle collection
- [x] Test: `set_consent(true, true, true, true)` — events appear in DebugView
- [x] Test: `set_consent(false, false, false, false)` — events stop appearing
- [x] Test: `set_consent(false, true)` — backwards compatible with defaults
- [x] Verify events appear in Firebase Console DebugView in real-time
- [x] Verify analytics-consent docs page renders correctly on GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)