### PR TITLE
fix(firestore): JSON String params for cross-platform API symmetry

### DIFF
--- a/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseFirestorePlugin.swift
+++ b/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseFirestorePlugin.swift
@@ -206,24 +206,40 @@ class FirebaseFirestorePlugin: RefCounted, @unchecked Sendable {
     // MARK: - Query Documents
 
     @Callable
-    func query_documents(collection: String, filters: GArray, orderBy: String, orderDescending: Bool, limitCount: Int) {
+    func query_documents(collection: String, filtersJson: String, orderBy: String, orderDescending: Bool, limitCount: Int) {
         guard let db else {
             Task { @MainActor in self.query_task_completed.emit(self.buildResult(status: false, docID: "", error: "Firestore not initialized")) }
             return
         }
         var query: Query = db.collection(collection)
 
-        // Apply filters
-        for i in 0..<filters.size() {
-            guard let filterVariant = filters[Int(i)],
-                  let filterDict = GDictionary(filterVariant),
-                  let fieldVariant = filterDict[Variant("field")],
-                  let field = String(fieldVariant),
-                  let opVariant = filterDict[Variant("op")],
-                  let op = String(opVariant),
-                  let valueVariant = filterDict[Variant("value")] else { continue }
+        // Parse filters from JSON
+        guard let data = filtersJson.data(using: .utf8) else {
+            let result = buildResult(status: false, docID: "", error: "Invalid filters JSON: not UTF-8")
+            Task { @MainActor in self.query_task_completed.emit(result) }
+            return
+        }
 
-            let value = variantToSwift(valueVariant)
+        let parsed: [[String: Any]]
+        do {
+            let obj = try JSONSerialization.jsonObject(with: data, options: [])
+            guard let arr = obj as? [[String: Any]] else {
+                let result = buildResult(status: false, docID: "", error: "Filters JSON must be an array of objects")
+                Task { @MainActor in self.query_task_completed.emit(result) }
+                return
+            }
+            parsed = arr
+        } catch {
+            let result = buildResult(status: false, docID: "", error: "Invalid filters JSON: \(error.localizedDescription)")
+            Task { @MainActor in self.query_task_completed.emit(result) }
+            return
+        }
+
+        // Apply filters
+        for item in parsed {
+            guard let field = item["field"] as? String,
+                  let op = item["op"] as? String,
+                  let value = item["value"] else { continue }
 
             switch op {
             case "==":
@@ -241,17 +257,14 @@ class FirebaseFirestorePlugin: RefCounted, @unchecked Sendable {
             case "array_contains":
                 query = query.whereField(field, arrayContains: value)
             case "in":
-                if let arr = value as? [Any] {
-                    query = query.whereField(field, in: arr)
-                }
+                let list = (value as? [Any]) ?? [value]
+                query = query.whereField(field, in: list)
             case "not_in":
-                if let arr = value as? [Any] {
-                    query = query.whereField(field, notIn: arr)
-                }
+                let list = (value as? [Any]) ?? [value]
+                query = query.whereField(field, notIn: list)
             case "array_contains_any":
-                if let arr = value as? [Any] {
-                    query = query.whereField(field, arrayContainsAny: arr)
-                }
+                let list = (value as? [Any]) ?? [value]
+                query = query.whereField(field, arrayContainsAny: list)
             default:
                 break
             }
@@ -433,18 +446,18 @@ class FirebaseFirestorePlugin: RefCounted, @unchecked Sendable {
     }
 
     @Callable
-    func array_union(elements: GArray) -> GDictionary {
+    func array_union(elementsJson: String) -> GDictionary {
         var dict = GDictionary()
         dict[Variant("__type")] = Variant("arrayUnion")
-        dict[Variant("elements")] = Variant(elements)
+        dict[Variant("elementsJson")] = Variant(elementsJson)
         return dict
     }
 
     @Callable
-    func array_remove(elements: GArray) -> GDictionary {
+    func array_remove(elementsJson: String) -> GDictionary {
         var dict = GDictionary()
         dict[Variant("__type")] = Variant("arrayRemove")
-        dict[Variant("elements")] = Variant(elements)
+        dict[Variant("elementsJson")] = Variant(elementsJson)
         return dict
     }
 
@@ -500,13 +513,13 @@ class FirebaseFirestorePlugin: RefCounted, @unchecked Sendable {
                         }
                         continue
                     case "arrayUnion":
-                        if let elemVariant = innerDict[Variant("elements")], let elements = GArray(elemVariant) {
-                            result[keyStr] = FieldValue.arrayUnion(gdArrayToSwift(elements))
+                        if let jsonVariant = innerDict[Variant("elementsJson")], let json = String(jsonVariant) {
+                            result[keyStr] = FieldValue.arrayUnion(parseJsonElementsArray(json))
                         }
                         continue
                     case "arrayRemove":
-                        if let elemVariant = innerDict[Variant("elements")], let elements = GArray(elemVariant) {
-                            result[keyStr] = FieldValue.arrayRemove(gdArrayToSwift(elements))
+                        if let jsonVariant = innerDict[Variant("elementsJson")], let json = String(jsonVariant) {
+                            result[keyStr] = FieldValue.arrayRemove(parseJsonElementsArray(json))
                         }
                         continue
                     default:
@@ -552,6 +565,17 @@ class FirebaseFirestorePlugin: RefCounted, @unchecked Sendable {
             result.append(variantToSwift(variant))
         }
         return result
+    }
+
+    private func parseJsonElementsArray(_ json: String) -> [Any] {
+        guard !json.isEmpty,
+              let data = json.data(using: .utf8) else { return [] }
+        do {
+            let obj = try JSONSerialization.jsonObject(with: data, options: [])
+            return (obj as? [Any]) ?? []
+        } catch {
+            return []
+        }
     }
 
     // MARK: - Data Conversion: Swift → GDictionary

--- a/demo/addons/GodotFirebaseiOS/modules/Firestore.gd
+++ b/demo/addons/GodotFirebaseiOS/modules/Firestore.gd
@@ -69,7 +69,7 @@ func stop_listening_to_document(document_path: String) -> void:
 
 func query_documents(collection: String, filters: Array = [], order_by: String = "", order_descending: bool = false, limit_count: int = 0) -> void:
 	if _plugin:
-		_plugin.query_documents(collection, filters, order_by, order_descending, limit_count)
+		_plugin.query_documents(collection, JSON.stringify(filters), order_by, order_descending, limit_count)
 
 # Collection Listeners
 
@@ -119,12 +119,12 @@ func server_timestamp() -> Dictionary:
 
 func array_union(elements: Array) -> Dictionary:
 	if _plugin:
-		return _plugin.array_union(elements)
+		return _plugin.array_union(JSON.stringify(elements))
 	return {}
 
 func array_remove(elements: Array) -> Dictionary:
 	if _plugin:
-		return _plugin.array_remove(elements)
+		return _plugin.array_remove(JSON.stringify(elements))
 	return {}
 
 func increment_by(value: int) -> Dictionary:


### PR DESCRIPTION
## Summary
- Mirrors SomniGameStudios/godot-firebase-android#6 (fix/firestore-json-filters).
- Android cannot use GArray-equivalent JNI types reliably (Kotlin `Array<Any?>` crashes on-device with typed-element-mismatch). Android is moving to `String` (JSON) for three Firestore parameter types; iOS must match so GDScript-side callers have one API shape across platforms.
- iOS Swift side is not itself broken — Swift GArray uses Godot's Variant wrapper without JVM generic reflection. This is an API-shape change for symmetry, not a bug fix per se. But shipping the Android fix without iOS symmetry would force GDScript to branch on platform at every call site.

## Methods changed
- `query_documents(collection, filtersJson: String, orderBy, orderDescending, limitCount)` — was `filters: GArray`
- `array_union(elementsJson: String) -> GDictionary` — was `elements: GArray`
- `array_remove(elementsJson: String) -> GDictionary` — was `elements: GArray`
- `gdDictToSwift`: arrayUnion/arrayRemove sentinel branches updated to parse `elementsJson` via `parseJsonElementsArray()` helper
- GDScript wrapper (`demo/addons/GodotFirebaseiOS/modules/Firestore.gd`): public API unchanged (accepts Array), `JSON.stringify()` at the plugin call boundary

## Test plan
- [ ] Swift build succeeds (SPM / xcodebuild) — deferred: Xcode required, cannot invoke from shell
- [ ] On-device test with query_documents filters (TestFlight or local device build)
- [ ] Coordinated release with godot-firebase-android#6

## References
- Sibling PR: SomniGameStudios/godot-firebase-android#6