### PR TITLE
feat: add hasGoogle/hasApple boolean flags to getCurrentUser()

### DIFF
--- a/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseAuthPlugin.swift
+++ b/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseAuthPlugin.swift
@@ -661,6 +661,10 @@ class FirebaseAuthPlugin: RefCounted, @unchecked Sendable {
         }
         dict[Variant("metadata")] = Variant(metadata)
 
+        dict[Variant("hasGoogle")] = Variant(user.providerData.contains { $0.providerID == "google.com" })
+        dict[Variant("hasApple")] = Variant(user.providerData.contains { $0.providerID == "apple.com" })
+        dict[Variant("providerIds")] = Variant(user.providerData.map { $0.providerID }.joined(separator: ","))
+
         var providers = GArray()
         for provider in user.providerData {
             var p = GDictionary()

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -353,6 +353,23 @@ FirebaseIOS.auth.reauthenticate_with_email("user@example.com", "password123")
 
 ---
 
+## Prerequisites
+
+### Apple Sign-In
+
+Apple Sign-In requires the **Sign in with Apple** entitlement. Without it, `sign_in_with_apple()` and `link_with_apple()` will fail with `ASAuthorizationError error 1000`.
+
+1. **Godot Export Presets:** iOS export > Entitlements > Additional — append:
+   ```
+   <key>com.apple.developer.applesignin</key>
+   <array><string>Default</string></array>
+   ```
+2. **Apple Developer Portal:** Certificates, Identifiers & Profiles > your App ID > enable "Sign in with Apple"
+
+### Google Sign-In
+
+Google Sign-In requires the `REVERSED_CLIENT_ID` URL scheme in your `Info.plist` (from `GoogleService-Info.plist`). See [Firebase docs](https://firebase.google.com/docs/auth/ios/google-signin).
+
 ## Known Limitations
 
 - Google Sign-In requires a physical iOS device (arm64). The iOS Simulator is not supported.


### PR DESCRIPTION
## Summary
- Adds `hasGoogle` and `hasApple` boolean fields + `providerIds` (comma-separated string) to the `get_current_user()` return value
- Mirrors Android plugin's `getCurrentUser()` provider detection (commit `63a8a87`)
- Adds Apple Sign-In and Google Sign-In prerequisites to `docs/authentication.md`

## Motivation
stepland-app's `firebase_auth_wrapper.gd` uses `hasGoogle`/`hasApple` to determine which sign-in provider is active (account linking flow). Both plugins must return the same shape.

## Test plan
- [ ] Sign in with Google on iOS — `hasGoogle=true`, `hasApple=false`
- [ ] Sign in with Apple on iOS — `hasApple=true`, `hasGoogle=false`
- [ ] Confirm `providerIds` string contains expected provider IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)