### PR TITLE
fix: mirror Android Firestore query result contract on iOS

### DIFF
--- a/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseFirestorePlugin.swift
+++ b/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseFirestorePlugin.swift
@@ -295,11 +295,11 @@ class FirebaseFirestorePlugin: RefCounted, @unchecked Sendable {
                     flatDoc["_docID"] = doc.documentID
                     serializedDocs.append(flatDoc)
                 }
-                let result = self.buildQueryResult(
-                    status: true,
-                    collection: collection,
-                    documentsJson: self.encodeDocumentsJson(serializedDocs)
-                )
+                guard let json = self.encodeDocumentsJson(serializedDocs) else {
+                    self.query_task_completed.emit(self.buildQueryResult(status: false, collection: collection, error: "Failed to serialize query results to JSON"))
+                    return
+                }
+                let result = self.buildQueryResult(status: true, collection: collection, documentsJson: json)
                 self.query_task_completed.emit(result)
             }
         }
@@ -610,12 +610,12 @@ class FirebaseFirestorePlugin: RefCounted, @unchecked Sendable {
         return dict
     }
 
-    private func encodeDocumentsJson(_ documents: [[String: Any]]) -> String {
+    private func encodeDocumentsJson(_ documents: [[String: Any]]) -> String? {
         guard JSONSerialization.isValidJSONObject(documents),
               let data = try? JSONSerialization.data(withJSONObject: documents, options: []) else {
-            return "[]"
+            return nil
         }
-        return String(data: data, encoding: .utf8) ?? "[]"
+        return String(data: data, encoding: .utf8)
     }
 
     private func toJsonSafe(_ value: Any) -> Any {
@@ -633,7 +633,7 @@ class FirebaseFirestorePlugin: RefCounted, @unchecked Sendable {
         case let s as String:
             return s
         case let ts as Timestamp:
-            return ts.seconds
+            return ISO8601DateFormatter().string(from: ts.dateValue())
         case let dict as [String: Any]:
             return docDataToSwiftDictionary(dict)
         case let arr as [Any]:

--- a/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseFirestorePlugin.swift
+++ b/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseFirestorePlugin.swift
@@ -208,14 +208,14 @@ class FirebaseFirestorePlugin: RefCounted, @unchecked Sendable {
     @Callable
     func query_documents(collection: String, filtersJson: String, orderBy: String, orderDescending: Bool, limitCount: Int) {
         guard let db else {
-            Task { @MainActor in self.query_task_completed.emit(self.buildResult(status: false, docID: "", error: "Firestore not initialized")) }
+            Task { @MainActor in self.query_task_completed.emit(self.buildQueryResult(status: false, collection: collection, error: "Firestore not initialized")) }
             return
         }
         var query: Query = db.collection(collection)
 
         // Parse filters from JSON
         guard let data = filtersJson.data(using: .utf8) else {
-            let result = buildResult(status: false, docID: "", error: "Invalid filters JSON: not UTF-8")
+            let result = buildQueryResult(status: false, collection: collection, error: "Invalid filters JSON: not UTF-8")
             Task { @MainActor in self.query_task_completed.emit(result) }
             return
         }
@@ -224,13 +224,13 @@ class FirebaseFirestorePlugin: RefCounted, @unchecked Sendable {
         do {
             let obj = try JSONSerialization.jsonObject(with: data, options: [])
             guard let arr = obj as? [[String: Any]] else {
-                let result = buildResult(status: false, docID: "", error: "Filters JSON must be an array of objects")
+                let result = buildQueryResult(status: false, collection: collection, error: "Filters JSON must be an array of objects")
                 Task { @MainActor in self.query_task_completed.emit(result) }
                 return
             }
             parsed = arr
         } catch {
-            let result = buildResult(status: false, docID: "", error: "Invalid filters JSON: \(error.localizedDescription)")
+            let result = buildQueryResult(status: false, collection: collection, error: "Invalid filters JSON: \(error.localizedDescription)")
             Task { @MainActor in self.query_task_completed.emit(result) }
             return
         }
@@ -284,23 +284,22 @@ class FirebaseFirestorePlugin: RefCounted, @unchecked Sendable {
             guard let self else { return }
             Task { @MainActor in
                 if let error {
-                    self.query_task_completed.emit(self.buildResult(status: false, docID: "", error: error.localizedDescription))
+                    self.query_task_completed.emit(self.buildQueryResult(status: false, collection: collection, error: error.localizedDescription))
                     return
                 }
-                guard let documents = querySnapshot?.documents else {
-                    self.query_task_completed.emit(self.buildResult(status: true, docID: ""))
-                    return
-                }
-                var docsArray = GArray()
+                let documents = querySnapshot?.documents ?? []
+                var serializedDocs: [[String: Any]] = []
+                serializedDocs.reserveCapacity(documents.count)
                 for doc in documents {
-                    var docDict = GDictionary()
-                    docDict[Variant("docID")] = Variant(doc.documentID)
-                    docDict[Variant("data")] = Variant(self.docDataToGDDict(doc.data()))
-                    docsArray.append(Variant(docDict))
+                    var flatDoc = self.docDataToSwiftDictionary(doc.data())
+                    flatDoc["_docID"] = doc.documentID
+                    serializedDocs.append(flatDoc)
                 }
-                var result = GDictionary()
-                result[Variant("status")] = Variant(true)
-                result[Variant("documents")] = Variant(docsArray)
+                let result = self.buildQueryResult(
+                    status: true,
+                    collection: collection,
+                    documentsJson: self.encodeDocumentsJson(serializedDocs)
+                )
                 self.query_task_completed.emit(result)
             }
         }
@@ -487,6 +486,15 @@ class FirebaseFirestorePlugin: RefCounted, @unchecked Sendable {
         return result
     }
 
+    private func buildQueryResult(status: Bool, collection: String, documentsJson: String? = nil, error: String? = nil) -> GDictionary {
+        var result = GDictionary()
+        result[Variant("status")] = Variant(status)
+        result[Variant("collection")] = Variant(collection)
+        if let documentsJson { result[Variant("documents_json")] = Variant(documentsJson) }
+        if let error { result[Variant("error")] = Variant(error) }
+        return result
+    }
+
     // MARK: - Data Conversion: GDictionary → Swift
 
     private func gdDictToSwift(_ gdDict: GDictionary) -> [String: Any] {
@@ -591,6 +599,48 @@ class FirebaseFirestorePlugin: RefCounted, @unchecked Sendable {
             dict[Variant(key)] = swiftToVariant(value)
         }
         return dict
+    }
+
+    private func docDataToSwiftDictionary(_ data: [String: Any]) -> [String: Any] {
+        var dict: [String: Any] = [:]
+        dict.reserveCapacity(data.count)
+        for (key, value) in data {
+            dict[key] = toJsonSafe(value)
+        }
+        return dict
+    }
+
+    private func encodeDocumentsJson(_ documents: [[String: Any]]) -> String {
+        guard JSONSerialization.isValidJSONObject(documents),
+              let data = try? JSONSerialization.data(withJSONObject: documents, options: []) else {
+            return "[]"
+        }
+        return String(data: data, encoding: .utf8) ?? "[]"
+    }
+
+    private func toJsonSafe(_ value: Any) -> Any {
+        switch value {
+        case let b as Bool:
+            return b
+        case let i as Int:
+            return i
+        case let i as Int64:
+            return Int(i)
+        case let d as Double:
+            return d
+        case let f as Float:
+            return Double(f)
+        case let s as String:
+            return s
+        case let ts as Timestamp:
+            return ts.seconds
+        case let dict as [String: Any]:
+            return docDataToSwiftDictionary(dict)
+        case let arr as [Any]:
+            return arr.map { toJsonSafe($0) }
+        default:
+            return String(describing: value)
+        }
     }
 
     private func swiftToVariant(_ value: Any) -> Variant {

--- a/demo/scenes/firestore.gd
+++ b/demo/scenes/firestore.gd
@@ -35,7 +35,17 @@ func _on_document_changed(document_path: String, data: Dictionary) -> void:
 	_log("listener", "path=%s data=%s" % [document_path, JSON.stringify(data)])
 
 func _on_query_completed(result: Dictionary) -> void:
-	_log("query", "status=%s docs=%s" % [result.get("status"), JSON.stringify(result.get("documents", []))])
+	var docs_json: String = result.get("documents_json", "")
+	var docs: Variant = result.get("documents", [])
+	if docs_json != "":
+		var parsed: Variant = JSON.parse_string(docs_json)
+		if parsed is Array:
+			docs = parsed
+	_log("query", "status=%s collection=%s docs=%s" % [
+		result.get("status"),
+		result.get("collection", ""),
+		JSON.stringify(docs),
+	])
 
 func _on_collection_changed(collection_path: String, documents: Array) -> void:
 	_log("collection", "path=%s count=%d" % [collection_path, documents.size()])

--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -34,7 +34,7 @@ All task signals emit a single `result: Dictionary` with the following keys:
   Emitted when a listened document changes in real time.
 
 - `query_task_completed(result: Dictionary)`
-  Emitted after `query_documents()`. Result contains `{status: bool, documents: Array, error?: String}`. Each document in the array is `{docID: String, data: Dictionary}`.
+  Emitted after `query_documents()`. Result contains `{status: bool, collection: String, documents_json?: String, error?: String}`. On success, `documents_json` is a JSON array of flat documents shaped like `{"_docID": "...", ...fields}`.
 
 - `collection_changed(collection_path: String, documents: Array)`
   Emitted when a listened collection changes. Each document in the array is `{docID: String, data: Dictionary}`.
@@ -167,7 +167,7 @@ FirebaseIOS.firestore.use_emulator("localhost", 8080)
 
 Queries documents with filters, ordering, and limits. Filters is an Array of Dictionaries: `[{"field": "score", "op": ">", "value": 100}]`. Supported operators: `==`, `!=`, `<`, `<=`, `>`, `>=`, `array_contains`, `in`, `not_in`, `array_contains_any`.
 
-**Emits:** `query_task_completed`.
+**Emits:** `query_task_completed` with `collection` echoed back and `documents_json` on success.
 
 ```gdscript
 FirebaseIOS.firestore.query_documents("users", [{"field": "score", "op": ">", "value": 100}], "score", true, 10)


### PR DESCRIPTION
## Summary
- mirror the Android Firestore query result contract in the iOS plugin
- echo collection for query_documents results and return documents_json with flat _docID documents
- update the demo and Firestore docs to reflect the new payload shape

## Verification
- built the iOS framework successfully with ./build_and_copy.sh

## Follow-up before merge
- verify on device in stepland-app that the Friends page loads friends and requests on first open without pressing reload
- keep same-collection query serialization in app code because the plugin still does not return a request id for concurrent same-collection queries