### PR TITLE
Depend on shared SwiftGodotRuntime instead of bundling it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ demo/addons/GodotFirebaseiOS/GodotFirebaseiOS.framework
 demo/addons/GodotFirebaseiOS/GodotFirebaseiOS.xcframework
 demo/addons/GodotFirebaseiOS/GodotFirebaseiOS.framework.dSYM
 
+# Shared SwiftGodot runtime — third-party addon, install to run the demo (see README)
+demo/addons/GodotApplePluginsRuntime/
+
 
 # MSVC build artifacts
 *.obj
@@ -38,4 +41,3 @@ compile_log.txt
 # IDE
 .idea/
 /.claude
-demo/addons/GodotFirebaseiOS/SwiftGodotRuntime.xcframework

--- a/GodotFirebaseiOS/Package.resolved
+++ b/GodotFirebaseiOS/Package.resolved
@@ -177,7 +177,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/migueldeicaza/SwiftGodot",
       "state" : {
-        "revision" : "d54c377787fbf9276712de25e1fcd7b709d6bba9"
+        "revision" : "ead7bffc9546c1740678a36096282e1a811b7da6"
       }
     }
   ],

--- a/GodotFirebaseiOS/Package.swift
+++ b/GodotFirebaseiOS/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "GodotFirebaseiOS", type: .dynamic, targets: ["GodotFirebaseiOS"])
     ],
     dependencies: [
-        .package(url: "https://github.com/migueldeicaza/SwiftGodot", revision: "d54c377787fbf9276712de25e1fcd7b709d6bba9"),
+        .package(url: "https://github.com/migueldeicaza/SwiftGodot", revision: "ead7bffc9546c1740678a36096282e1a811b7da6"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "11.0.0"),
         .package(url: "https://github.com/google/GoogleSignIn-iOS", from: "9.1.0")
     ],

--- a/GodotFirebaseiOS/build_and_copy.sh
+++ b/GodotFirebaseiOS/build_and_copy.sh
@@ -46,28 +46,14 @@ if [ ! -d "$FRAMEWORK_SOURCE" ]; then
   exit 1
 fi
 
-# Locate SwiftGodotRuntime
-RUNTIME_SOURCE="$BUILD_PATH/Build/Products/$CONFIGURATION-iphoneos/PackageFrameworks/SwiftGodotRuntime.framework"
-RUNTIME_XCFRAMEWORK_OUT="$BUILD_PATH/SwiftGodotRuntime.xcframework"
-
-if [ ! -d "$RUNTIME_SOURCE" ]; then
-  RUNTIME_SOURCE="$BUILD_PATH/Build/Products/$CONFIGURATION-iphoneos/SwiftGodotRuntime.framework"
-fi
-
-if [ ! -d "$RUNTIME_SOURCE" ]; then
-  echo "❌ Error: SwiftGodotRuntime.framework not found"
-  exit 1
-fi
-
 if [ ! -d "$DSYM_SOURCE" ]; then
   echo "⚠️ Warning: dSYM not found at $DSYM_SOURCE. Archive warnings may persist."
 fi
 
-# --- Create XCFrameworks ---
+# --- Create XCFramework ---
 
-echo "📦 Creating XCFrameworks..."
+echo "📦 Creating XCFramework..."
 rm -rf "$XCFRAMEWORK_OUT"
-rm -rf "$RUNTIME_XCFRAMEWORK_OUT"
 
 # Plugin XCFramework
 if [ -d "$DSYM_SOURCE" ]; then
@@ -81,22 +67,18 @@ else
     -output "$XCFRAMEWORK_OUT"
 fi
 
-# Runtime XCFramework (shared core)
-xcodebuild -create-xcframework \
-  -framework "$RUNTIME_SOURCE" \
-  -output "$RUNTIME_XCFRAMEWORK_OUT"
-
 # --- Addon Update ---
 
 echo "📦 Updating addon folder..."
 
-# Clean up old xcframeworks and copy the fresh ones
+# Clean up old xcframeworks and copy the fresh one.
+# SwiftGodotRuntime is intentionally not bundled — it is provided by the
+# GodotApplePluginsRuntime addon (see README "Dependencies").
 rm -rf "$ADDON_PATH/GodotFirebaseiOS.framework"
 rm -rf "$ADDON_PATH/GodotFirebaseiOS.framework.dSYM"
 rm -rf "$ADDON_PATH/GodotFirebaseiOS.xcframework"
 rm -rf "$ADDON_PATH/SwiftGodotRuntime.xcframework"
 
 cp -r "$XCFRAMEWORK_OUT" "$ADDON_PATH/"
-cp -r "$RUNTIME_XCFRAMEWORK_OUT" "$ADDON_PATH/"
 
 echo "✅ Done! Addon updated at $ADDON_PATH"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,28 @@ Full installation guide, API reference, and examples.
 
 ---
 
+## Dependencies
+
+This plugin does **not** bundle the SwiftGodot runtime. It depends on the shared
+`SwiftGodotRuntime` framework provided by the
+[`GodotApplePluginsRuntime`](https://github.com/migueldeicaza/GodotApplePlugins)
+addon.
+
+Install `GodotApplePluginsRuntime` into your project's `addons/` folder
+alongside this plugin — even if you do not use any other GodotApplePlugins
+addon. The `.gdextension` manifest declares it as a native iOS dependency at
+`res://addons/GodotApplePluginsRuntime/bin/SwiftGodotRuntime.xcframework`, so
+Godot embeds it in the iOS export.
+
+Both this plugin and the `GodotApplePluginsRuntime` build must be compiled
+against the **same SwiftGodot revision**, or the iOS app will fail to launch
+with Swift symbol-not-found errors. This plugin is pinned to the SwiftGodot
+revision in [`GodotFirebaseiOS/Package.swift`](GodotFirebaseiOS/Package.swift)
+(currently `ead7bffc9546c1740678a36096282e1a811b7da6`). Use a
+`GodotApplePluginsRuntime` release built from the same revision.
+
+---
+
 ## Requirements
 
 | Tool | Minimum |

--- a/demo/addons/GodotFirebaseiOS/GodotFirebaseiOS.gdextension
+++ b/demo/addons/GodotFirebaseiOS/GodotFirebaseiOS.gdextension
@@ -18,5 +18,5 @@ android.release.x86_64 = "stubs/libstub_android.so"
 
 [dependencies]
 ios = {
-    "SwiftGodotRuntime.xcframework": ""
+    "res://addons/GodotApplePluginsRuntime/bin/SwiftGodotRuntime.xcframework": ""
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,11 @@ Designed to work alongside [GodotFirebaseAndroid](https://github.com/syntaxerror
 
 1. Download the latest release zip from [Releases](https://github.com/SomniGameStudios/godot-firebase-ios/releases).
 2. Extract `addons/GodotFirebaseiOS/` into your project's `addons/` folder.
-3. Enable the plugin in **Project → Project Settings → Plugins**. The `FirebaseIOS` autoload is registered automatically.
-4. Place your `GoogleService-Info.plist` in `addons/GodotFirebaseiOS/`.
+3. Install the shared SwiftGodot runtime: download [GodotApplePlugins](https://github.com/migueldeicaza/GodotApplePlugins/releases) and extract its `addons/GodotApplePluginsRuntime/` into your project's `addons/` folder. This plugin depends on it for the iOS export and does not bundle its own copy.
+4. Enable the plugin in **Project → Project Settings → Plugins**. The `FirebaseIOS` autoload is registered automatically.
+5. Place your `GoogleService-Info.plist` in `addons/GodotFirebaseiOS/`.
+
+> **Version match:** this plugin and `GodotApplePluginsRuntime` must be built against the same SwiftGodot revision, or the iOS app will crash at launch with Swift symbol errors. See the [README](https://github.com/SomniGameStudios/godot-firebase-ios#dependencies) for the pinned revision.
 
 ## Requirements
 


### PR DESCRIPTION
## Why

The plugin bundles its own `SwiftGodotRuntime.xcframework`. When a project also installs any [`GodotApplePlugins`](https://github.com/migueldeicaza/GodotApplePlugins) addon (StoreKit, Notifications, …), that addon ships the **same** runtime. Godot's iOS export then wires two copy commands targeting the same `<app>/Frameworks/SwiftGodotRuntime.framework`, and Xcode fails:

```
Multiple commands produce '…/Frameworks/SwiftGodotRuntime.framework'
Multiple commands produce '…/Frameworks/SwiftGodotRuntime.framework/SwiftGodotRuntime'
```

This blocks any game combining this plugin with GodotApplePlugins (e.g. Stepland, which ships StoreKit for subscriptions).

## What changed

- **`GodotFirebaseiOS.gdextension`** — iOS dependency now points at the shared runtime: `res://addons/GodotApplePluginsRuntime/bin/SwiftGodotRuntime.xcframework`.
- **`build_and_copy.sh`** — stops packaging and copying `SwiftGodotRuntime.xcframework` into the addon. SwiftGodot is still compiled (it's a SwiftPM dependency); we just no longer redistribute it.
- **`Package.swift` / `Package.resolved`** — SwiftGodot pin bumped `d54c377` → `ead7bff` to match the revision `GodotApplePlugins` builds its runtime from (see below).
- **`.gitignore`** — drop the now-irrelevant bundled-runtime entry; ignore the demo's third-party `GodotApplePluginsRuntime` install.
- **`README.md` / `docs/index.md`** — document the new dependency and the version-match requirement.

## The ABI alignment (important)

`SwiftGodotRuntime` is a Swift framework. The plugin framework and the runtime framework must be compiled against the **same SwiftGodot revision** or the iOS app crashes at launch with Swift symbol-not-found errors.

- `GodotApplePlugins` ([run 26231567751](https://github.com/migueldeicaza/GodotApplePlugins/actions/runs/26231567751), commit `6f19774`) pins SwiftGodot at **`ead7bffc9546c1740678a36096282e1a811b7da6`**.
- This plugin previously pinned **`d54c377787fbf9276712de25e1fcd7b709d6bba9`** — different ABI.

This PR bumps our pin to `ead7bff` so both link the same ABI.

## Draft — pre-merge checklist

- [x] **CI Build** compiles the Firebase Swift sources against SwiftGodot `ead7bff`. If the API moved between `d54c377` and `ead7bff`, source fixes are needed here.
- [x] `Package.resolved` regenerates cleanly on first build (`originHash` recomputes — the hand-edited revision triggers a re-resolve).
- [x] Device smoke test: a Godot project with this plugin + `GodotApplePluginsRuntime` installed exports to iOS, builds in Xcode with **no** "Multiple commands produce" error, and launches without Swift symbol crashes.
- [x] Release notes for the next version flag this as a **breaking change**: consumers must now also install `GodotApplePluginsRuntime`.

## Notes for consumers

This is a breaking change. After upgrading, install `GodotApplePluginsRuntime` (from a GodotApplePlugins release built against the same SwiftGodot revision) into `addons/` alongside this plugin.