### PR TITLE
fix(ios): prevent dead-stripping with -rdynamic and fix simulator consent crash

### DIFF
--- a/GodotFirebaseiOS/project.yml
+++ b/GodotFirebaseiOS/project.yml
@@ -17,74 +17,11 @@ targets:
     dependencies:
       - package: SwiftGodot
         product: SwiftGodotRuntime
-      - framework: ../firebase_sdk/AppAuth.xcframework
-        embed: false
-      - framework: ../firebase_sdk/AppCheckCore.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FBLPromises.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FirebaseABTesting.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FirebaseAnalytics.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FirebaseAppCheckInterop.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FirebaseAuth.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FirebaseAuthInterop.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FirebaseCore.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FirebaseCoreExtension.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FirebaseCoreInternal.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FirebaseDatabase.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FirebaseFirestore.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FirebaseFirestoreInternal.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FirebaseInstallations.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FirebaseMessaging.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FirebaseMessagingInterop.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FirebaseRemoteConfig.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FirebaseRemoteConfigInterop.xcframework
-        embed: false
-      - framework: ../firebase_sdk/FirebaseSharedSwift.xcframework
-        embed: false
-      - framework: ../firebase_sdk/GTMAppAuth.xcframework
-        embed: false
-      - framework: ../firebase_sdk/GTMSessionFetcher.xcframework
-        embed: false
-      - framework: ../firebase_sdk/GoogleAppMeasurement.xcframework
-        embed: false
-      - framework: ../firebase_sdk/GoogleAppMeasurementIdentitySupport.xcframework
-        embed: false
-      - framework: ../firebase_sdk/GoogleDataTransport.xcframework
-        embed: false
-      - framework: ../firebase_sdk/GoogleSignIn.xcframework
-        embed: false
-      - framework: ../firebase_sdk/GoogleUtilities.xcframework
-        embed: false
-      - framework: ../firebase_sdk/RecaptchaInterop.xcframework
-        embed: false
-      - framework: ../firebase_sdk/absl.xcframework
-        embed: false
-      - framework: ../firebase_sdk/grpc.xcframework
-        embed: false
-      - framework: ../firebase_sdk/grpcpp.xcframework
-        embed: false
-      - framework: ../firebase_sdk/leveldb.xcframework
-        embed: false
-      - framework: ../firebase_sdk/nanopb.xcframework
-        embed: false
-      - framework: ../firebase_sdk/openssl_grpc.xcframework
-        embed: false
+        
+    postBuildScripts:
+      - script: |
+          find ../firebase_sdk -name "*.bundle" -exec cp -R {} "$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/" \;
+        name: Copy Firebase Bundles
     settings:
       base:
         PRODUCT_NAME: GodotFirebaseiOS
@@ -92,6 +29,13 @@ targets:
         SWIFT_VERSION: "5.0"
         BUILD_LIBRARY_FOR_DISTRIBUTION: YES
         GENERATE_INFOPLIST_FILE: YES
+        CLANG_MODULES_AUTOLINK: NO
+        "FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]":
+          - "$(inherited)"
+          - "$(PROJECT_DIR)/../firebase_sdk/ios-arm64"
+        "FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]":
+          - "$(inherited)"
+          - "$(PROJECT_DIR)/../firebase_sdk/ios-arm64_x86_64-simulator"
         OTHER_SWIFT_FLAGS:
           - "-suppress-warnings"
           - "-Xfrontend"
@@ -100,6 +44,8 @@ targets:
           - "-lto=llvm-full"
           - "-Xfrontend"
           - "-conditional-runtime-records"
+          - "-Xfrontend"
+          - "-disable-all-autolinking"
         OTHER_LDFLAGS:
           - "$(inherited)"
           - "-ObjC"

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,9 @@ all: build
 setup: setup-sdk setup-project
 
 setup-sdk:
-	@if [ ! -d "$(SDK_DIR)" ]; then \
+	@if [ ! -d "$(SDK_DIR)" ] || [ ! -d "$(SDK_DIR)/ios-arm64" ]; then \
 		echo "→ Downloading Firebase SDK $(FIREBASE_VERSION)..."; \
+		rm -rf $(SDK_DIR); \
 		mkdir -p $(ROOT_DIR)/tmp_firebase_download; \
 		curl -L -o $(ROOT_DIR)/tmp_firebase_download/Firebase.zip $(FIREBASE_ZIP_URL); \
 		unzip -oq $(ROOT_DIR)/tmp_firebase_download/Firebase.zip -d $(ROOT_DIR)/tmp_firebase_download/extracted; \
@@ -60,6 +61,14 @@ setup-sdk:
 		mkdir -p $(SDK_DIR); \
 		for fw in $(FRAMEWORKS); do \
 			find $(ROOT_DIR)/tmp_firebase_download/extracted -name "$$fw" -exec cp -R {} $(SDK_DIR)/ \; ; \
+		done; \
+		echo "→ Flattening framework slices..."; \
+		mkdir -p $(SDK_DIR)/ios-arm64; \
+		mkdir -p $(SDK_DIR)/ios-arm64_x86_64-simulator; \
+		for fw in $(FRAMEWORKS); do \
+			fw_name=$$(echo $$fw | sed 's/.xcframework//'); \
+			cp -R $(SDK_DIR)/$$fw/ios-arm64/$$fw_name.framework $(SDK_DIR)/ios-arm64/ 2>/dev/null || true; \
+			cp -R $(SDK_DIR)/$$fw/ios-arm64_x86_64-simulator/$$fw_name.framework $(SDK_DIR)/ios-arm64_x86_64-simulator/ 2>/dev/null || true; \
 		done; \
 		echo "→ Cleaning up temporary download files..."; \
 		rm -rf $(ROOT_DIR)/tmp_firebase_download; \
@@ -96,6 +105,9 @@ build: setup-project
 		CODE_SIGNING_ALLOWED=NO \
 		CODE_SIGNING_REQUIRED=NO \
 		| tail -20
+	@echo "→ Copying Firebase bundles into frameworks..."
+	@find $(SDK_DIR) -name "*.bundle" -exec cp -R {} $(BUILD_DIR)/xcodebuild/Build/Products/Release-iphoneos/GodotFirebaseiOS.framework/ \;
+	@find $(SDK_DIR) -name "*.bundle" -exec cp -R {} $(BUILD_DIR)/xcodebuild/Build/Products/Release-iphonesimulator/GodotFirebaseiOS.framework/ \;
 	@echo "→ Creating universal XCFramework..."
 	@rm -rf $(ROOT_DIR)/GodotFirebaseiOS.xcframework
 	@xcodebuild -create-xcframework \

--- a/demo/addons/GodotFirebaseiOS/GodotFirebaseiOS.gdextension
+++ b/demo/addons/GodotFirebaseiOS/GodotFirebaseiOS.gdextension
@@ -20,3 +20,4 @@ android.release.x86_64 = "stubs/libstub_android.so"
 ios = {
     "res://addons/GodotApplePluginsRuntime/bin/SwiftGodotRuntime.xcframework": ""
 }
+

--- a/demo/addons/GodotFirebaseiOS/export_plugin.gd
+++ b/demo/addons/GodotFirebaseiOS/export_plugin.gd
@@ -22,13 +22,56 @@ func _exit_tree() -> void:
 
 
 class iOSExportPlugin extends EditorExportPlugin:
+	const FRAMEWORKS_DIR := "res://addons/GodotFirebaseiOS/frameworks"
+
+	var _export_path := ""
+
+	const FIREBASE_FRAMEWORKS: PackedStringArray = [
+		"AppAuth.xcframework",
+		"AppCheckCore.xcframework",
+		"FBLPromises.xcframework",
+		"FirebaseABTesting.xcframework",
+		"FirebaseAnalytics.xcframework",
+		"FirebaseAppCheckInterop.xcframework",
+		"FirebaseAuth.xcframework",
+		"FirebaseAuthInterop.xcframework",
+		"FirebaseCore.xcframework",
+		"FirebaseCoreExtension.xcframework",
+		"FirebaseCoreInternal.xcframework",
+		"FirebaseDatabase.xcframework",
+		"FirebaseFirestore.xcframework",
+		"FirebaseFirestoreInternal.xcframework",
+		"FirebaseInstallations.xcframework",
+		"FirebaseMessaging.xcframework",
+		"FirebaseMessagingInterop.xcframework",
+		"FirebaseRemoteConfig.xcframework",
+		"FirebaseRemoteConfigInterop.xcframework",
+		"FirebaseSharedSwift.xcframework",
+		"GTMAppAuth.xcframework",
+		"GTMSessionFetcher.xcframework",
+		"GoogleAppMeasurement.xcframework",
+		"GoogleAppMeasurementIdentitySupport.xcframework",
+		"GoogleDataTransport.xcframework",
+		"GoogleSignIn.xcframework",
+		"GoogleUtilities.xcframework",
+		"RecaptchaInterop.xcframework",
+		"absl.xcframework",
+		"grpc.xcframework",
+		"grpcpp.xcframework",
+		"leveldb.xcframework",
+		"nanopb.xcframework",
+		"openssl_grpc.xcframework",
+	]
+
 	func _get_name() -> String:
 		return "GodotFirebaseiOS"
 
 	func _supports_platform(platform: EditorExportPlatform) -> bool:
 		return platform is EditorExportPlatformIOS
 
-	func _export_begin(features: PackedStringArray, _is_debug: bool, _path: String, _flags: int) -> void:
+	func _export_begin(features: PackedStringArray, _is_debug: bool, path: String, _flags: int) -> void:
+		_export_path = path
+		print("EXPORT FEATURES: ", features)
 		if not features.has("ios"):
 			return
 		const PLIST_PATH := "res://addons/GodotFirebaseiOS/GoogleService-Info.plist"
@@ -42,6 +85,7 @@ class iOSExportPlugin extends EditorExportPlugin:
 			return
 		add_ios_plist_content(_make_url_scheme_plist(reversed_client_id))
 		add_ios_plist_content(_make_fcm_plist())
+		add_ios_linker_flags("-ObjC")
 
 	func _extract_reversed_client_id(plist_path: String) -> String:
 		var parser := XMLParser.new()
@@ -82,3 +126,69 @@ class iOSExportPlugin extends EditorExportPlugin:
 </array>
 <key>FirebaseMessagingAutoInitEnabled</key>
 <false/>"""
+
+	func _export_end() -> void:
+		if _export_path.is_empty():
+			return
+		
+		var project_name := _export_path.get_file().get_basename()
+		var parent_dir := _export_path.get_base_dir()
+		var dest_dir := parent_dir.path_join(project_name).path_join("frameworks")
+		
+		var src_abs := ProjectSettings.globalize_path(FRAMEWORKS_DIR)
+		var dest_abs := ProjectSettings.globalize_path(dest_dir)
+		
+		# Ensure destination parent folder exists
+		DirAccess.make_dir_recursive_absolute(dest_abs.get_base_dir())
+		
+		# Clean previous frameworks folder if exists to avoid nested copies
+		if DirAccess.dir_exists_absolute(dest_abs):
+			OS.execute("rm", ["-rf", dest_abs])
+
+		var output := []
+		var exit_code := OS.execute("cp", ["-R", src_abs, dest_abs], output, true)
+		if exit_code != 0:
+			push_warning("GodotFirebaseiOS: Failed to copy frameworks directory. Exit code: %d" % exit_code)
+			return
+		else:
+			print("GodotFirebaseiOS: Copied frameworks to: ", dest_abs)
+
+		_modify_pbxproj(_export_path)
+		_export_path = ""
+
+	func _modify_pbxproj(path: String) -> void:
+		var pbxproj_path := path.path_join("project.pbxproj")
+		if not FileAccess.file_exists(pbxproj_path):
+			push_warning("GodotFirebaseiOS: project.pbxproj not found at " + pbxproj_path)
+			return
+		
+		var file := FileAccess.open(pbxproj_path, FileAccess.READ)
+		if not file:
+			push_warning("GodotFirebaseiOS: Failed to open project.pbxproj for reading")
+			return
+		var content := file.get_as_text()
+		file.close()
+
+		var project_name := path.get_file().get_basename()
+		var device_flags := ""
+		var simulator_flags := ""
+
+		for fw in FIREBASE_FRAMEWORKS:
+			var fw_name_no_ext := fw.replace(".xcframework", "")
+			device_flags += " -force_load \\\"$(PROJECT_DIR)/%s/frameworks/%s/ios-arm64/%s.framework/%s\\\"" % [project_name, fw, fw_name_no_ext, fw_name_no_ext]
+			simulator_flags += " -force_load \\\"$(PROJECT_DIR)/%s/frameworks/%s/ios-arm64_x86_64-simulator/%s.framework/%s\\\"" % [project_name, fw, fw_name_no_ext, fw_name_no_ext]
+
+		var target_str := "OTHER_LDFLAGS = \"$(LD_CLASSIC_$(XCODE_VERSION_ACTUAL)) -Wl,-U,_swift_entry_point -ObjC \";"
+		var replacement_str := "\"OTHER_LDFLAGS[sdk=iphoneos*]\" = \"$(LD_CLASSIC_$(XCODE_VERSION_ACTUAL)) -Wl,-U,_swift_entry_point -ObjC -rdynamic %s\";\n\t\t\t\t\"OTHER_LDFLAGS[sdk=iphonesimulator*]\" = \"$(LD_CLASSIC_$(XCODE_VERSION_ACTUAL)) -Wl,-U,_swift_entry_point -ObjC -rdynamic %s\";" % [device_flags, simulator_flags]
+
+		if content.contains(target_str):
+			content = content.replace(target_str, replacement_str)
+			var write_file := FileAccess.open(pbxproj_path, FileAccess.WRITE)
+			if write_file:
+				write_file.store_string(content)
+				write_file.close()
+				print("GodotFirebaseiOS: Successfully injected conditional force_load settings in project.pbxproj")
+			else:
+				push_warning("GodotFirebaseiOS: Failed to open project.pbxproj for writing")
+		else:
+			push_warning("GodotFirebaseiOS: Could not find OTHER_LDFLAGS pattern in project.pbxproj")


### PR DESCRIPTION
Reworks the plugin build system and export pipeline to use target-conditional static force-loading and injects -rdynamic to export symbols from the host app binary. This resolves the runtime crash of `_FIRConsentStatusDenied` inside the simulator.