### PR TITLE
fix(demo): enable touch-drag scrolling over the feature buttons

### DIFF
--- a/demo/project.godot
+++ b/demo/project.godot
@@ -34,6 +34,10 @@ window/handheld/orientation=1
 
 enabled=PackedStringArray("res://addons/GodotFirebaseiOS/plugin.cfg")
 
+[gui]
+
+common/default_scroll_deadzone=30
+
 [rendering]
 
 renderer/rendering_method="gl_compatibility"


### PR DESCRIPTION
The Automatic and Manual testing menus list their feature buttons inside a `ScrollContainer`. With the default scroll deadzone of `0`, a finger drag that starts on a `Button` is consumed by the button, so the list never scrolls on a touch device — off-screen entries can't be reached.

Sets `gui/common/default_scroll_deadzone = 30` so a drag past the threshold scrolls the list while taps still register as clicks. Affects both menu scenes. Demo-only change.