### PR TITLE
fix(firestore): Firestore integers 0 and 1 no longer deserialize as booleans

### DIFF
--- a/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseDatabasePlugin.swift
+++ b/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseDatabasePlugin.swift
@@ -221,16 +221,8 @@ class FirebaseDatabasePlugin: RefCounted, @unchecked Sendable {
     private func swiftToVariant(_ value: Any?) -> Variant {
         guard let value = value, !(value is NSNull) else { return Variant(GDictionary()) }
 
-        if let b = value as? Bool {
-            return Variant(b)
-        } else if let i = value as? Int {
-            return Variant(i)
-        } else if let i64 = value as? Int64 {
-            return Variant(Int(i64))
-        } else if let d = value as? Double {
-            return Variant(d)
-        } else if let f = value as? Float {
-            return Variant(Double(f))
+        if let n = value as? NSNumber {
+            return NSNumberBridging.toVariant(n)
         } else if let s = value as? String {
             return Variant(s)
         } else if let dict = value as? [String: Any] {

--- a/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseFirestorePlugin.swift
+++ b/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseFirestorePlugin.swift
@@ -623,16 +623,19 @@ class FirebaseFirestorePlugin: RefCounted, @unchecked Sendable {
 
     private func toJsonSafe(_ value: Any) -> Any {
         switch value {
-        case let b as Bool:
-            return b
-        case let i as Int:
-            return i
-        case let i as Int64:
-            return Int(i)
-        case let d as Double:
-            return d
-        case let f as Float:
-            return Double(f)
+        case let n as NSNumber:
+            // Firestore numbers arrive as NSNumber, and 0 and 1 pass an `as Bool`
+            // cast through bridging. Only a genuine CFBoolean is a bool; any other
+            // NSNumber is numeric, keyed off its objCType.
+            if CFGetTypeID(n as CFTypeRef) == CFBooleanGetTypeID() {
+                return n.boolValue
+            }
+            switch String(cString: n.objCType) {
+            case "f", "d":
+                return n.doubleValue
+            default:
+                return Int(truncating: n)
+            }
         case let s as String:
             return s
         case let ts as Timestamp:
@@ -648,14 +651,18 @@ class FirebaseFirestorePlugin: RefCounted, @unchecked Sendable {
 
     private func swiftToVariant(_ value: Any) -> Variant {
         switch value {
-        case let b as Bool:
-            return Variant(b)
-        case let i as Int:
-            return Variant(i)
-        case let i as Int64:
-            return Variant(Int(i))
-        case let d as Double:
-            return Variant(d)
+        case let n as NSNumber:
+            // Same CFBoolean disambiguation as toJsonSafe: NSNumber 0 and 1
+            // otherwise match `as Bool` and corrupt integer fields on read.
+            if CFGetTypeID(n as CFTypeRef) == CFBooleanGetTypeID() {
+                return Variant(n.boolValue)
+            }
+            switch String(cString: n.objCType) {
+            case "f", "d":
+                return Variant(n.doubleValue)
+            default:
+                return Variant(Int(truncating: n))
+            }
         case let s as String:
             return Variant(s)
         case let ts as Timestamp:

--- a/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseFirestorePlugin.swift
+++ b/GodotFirebaseiOS/Sources/GodotFirebaseiOS/FirebaseFirestorePlugin.swift
@@ -624,18 +624,7 @@ class FirebaseFirestorePlugin: RefCounted, @unchecked Sendable {
     private func toJsonSafe(_ value: Any) -> Any {
         switch value {
         case let n as NSNumber:
-            // Firestore numbers arrive as NSNumber, and 0 and 1 pass an `as Bool`
-            // cast through bridging. Only a genuine CFBoolean is a bool; any other
-            // NSNumber is numeric, keyed off its objCType.
-            if CFGetTypeID(n as CFTypeRef) == CFBooleanGetTypeID() {
-                return n.boolValue
-            }
-            switch String(cString: n.objCType) {
-            case "f", "d":
-                return n.doubleValue
-            default:
-                return Int(truncating: n)
-            }
+            return NSNumberBridging.toAny(n)
         case let s as String:
             return s
         case let ts as Timestamp:
@@ -652,17 +641,7 @@ class FirebaseFirestorePlugin: RefCounted, @unchecked Sendable {
     private func swiftToVariant(_ value: Any) -> Variant {
         switch value {
         case let n as NSNumber:
-            // Same CFBoolean disambiguation as toJsonSafe: NSNumber 0 and 1
-            // otherwise match `as Bool` and corrupt integer fields on read.
-            if CFGetTypeID(n as CFTypeRef) == CFBooleanGetTypeID() {
-                return Variant(n.boolValue)
-            }
-            switch String(cString: n.objCType) {
-            case "f", "d":
-                return Variant(n.doubleValue)
-            default:
-                return Variant(Int(truncating: n))
-            }
+            return NSNumberBridging.toVariant(n)
         case let s as String:
             return Variant(s)
         case let ts as Timestamp:

--- a/GodotFirebaseiOS/Sources/GodotFirebaseiOS/NSNumberBridging.swift
+++ b/GodotFirebaseiOS/Sources/GodotFirebaseiOS/NSNumberBridging.swift
@@ -1,0 +1,36 @@
+import Foundation
+import SwiftGodotRuntime
+
+/// Shared NSNumber handling for the Firebase read paths.
+///
+/// The Firebase SDKs return every numeric value as NSNumber, and NSNumber 0 and 1
+/// pass an `as Bool` cast through Swift's bridging, so integer (and double) fields
+/// holding 0 or 1 silently change type on read. Only a genuine CFBoolean is a
+/// boolean; any other NSNumber is numeric, keyed off its objCType ("f" and "d"
+/// are floating point, everything else integral). Checking objCType alone is not
+/// enough on arm64, where __NSCFBoolean reports "c".
+enum NSNumberBridging {
+    static func toAny(_ n: NSNumber) -> Any {
+        if CFGetTypeID(n as CFTypeRef) == CFBooleanGetTypeID() {
+            return n.boolValue
+        }
+        switch String(cString: n.objCType) {
+        case "f", "d":
+            return n.doubleValue
+        default:
+            return Int(truncating: n)
+        }
+    }
+
+    static func toVariant(_ n: NSNumber) -> Variant {
+        if CFGetTypeID(n as CFTypeRef) == CFBooleanGetTypeID() {
+            return Variant(n.boolValue)
+        }
+        switch String(cString: n.objCType) {
+        case "f", "d":
+            return Variant(n.doubleValue)
+        default:
+            return Variant(Int(truncating: n))
+        }
+    }
+}


### PR DESCRIPTION
## What

Fixes #37: Firestore integer values `0` and `1` were deserialized into Godot as `bool` `false`/`true` instead of `int`, in both read-side conversion paths (`toJsonSafe` and `swiftToVariant`).

Cause: the Firestore Objective-C SDK returns every numeric value as `NSNumber`, and Swift's exactness-checked bridging lets `NSNumber(0)` and `NSNumber(1)` succeed at `as Bool`, so the `case let b as Bool:` branch captured them before the `Int` branch could. Values outside `{0, 1}` fail that cast, which is why the bug only showed at the two most common values a counter takes.

Fix: both switches now match `NSNumber` first and ask the one reliable question, `CFGetTypeID(n) == CFBooleanGetTypeID()`. A genuine `__NSCFBoolean` is a distinct CF type from numeric `NSNumber`, so real booleans keep converting to bool, and everything else is marshaled by `objCType` (float/double vs integral). Checking `objCType` alone would not be enough on arm64, where `__NSCFBoolean` reports `"c"`.

The five per-type numeric cases collapse into the single `NSNumber` case because that is what the SDK actually hands over; `String`, `Timestamp`, dictionary, and array handling are untouched. The write path (`variantToSwift`) switches on `Variant.gtype` and was never affected.

While verifying, I found the same trap also hits doubles: `NSNumber(0.0)` and `NSNumber(1.0)` pass the `as Bool` cast too, so a Firestore double field holding exactly 0.0 or 1.0 was likewise read back as a bool. #37 only reported the integer case because that is what our schema exercises, but this fix covers both.

Side-by-side of the old and new conversion over real NSNumber values (pure Foundation, same bridging as iOS):

| input | old | new |
|---|---|---|
| `NSNumber(0)` / `NSNumber(1)` | `false` / `true` (Bool) | `0` / `1` (Int) |
| `NSNumber(0.0)` / `NSNumber(1.0)` | `false` / `true` (Bool) | `0.0` / `1.0` (Double) |
| `NSNumber(47)`, `NSNumber(-1)`, `NSNumber(Int64.max)` | Int | Int (unchanged) |
| `NSNumber(true)` / `kCFBooleanTrue` | Bool | Bool (unchanged) |
| `NSNumber(3.14)`, `NSNumber(Float(2.5))` | Double | Double (unchanged) |

## How to test

- `make setup && make build` succeeds locally on this branch.
- Device repro (how we found it, on 0.5.0, physical iPhone, 2026-05-15): store a Firestore field as number `1`, read the doc back through the plugin. Before: arrives as `true` (and `0` as `false`), while `5` and `47` arrive correctly. After: `0` and `1` arrive as ints, genuine booleans still arrive as bools.
- This conversion is pure NSNumber marshaling, so it is unit-testable without touching Firebase (`NSNumber(0)`, `NSNumber(1)`, `NSNumber(47)`, `kCFBooleanTrue`...). The repo has no test target today; happy to add one with that table in a follow-up PR if you want it.

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] `make setup && make build` succeeds locally
- [ ] The demo project still works for the affected feature (if applicable) — the fix is on the shared read path used by every Firestore read; happy to run a device pass against a CI build
