### PR TITLE
fix(build): propagate xcodebuild failures through the tail pipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+# Recipes pipe xcodebuild through tail, and make only sees the last command's
+# exit status. pipefail makes a failed xcodebuild fail the recipe instead of
+# silently packaging the previous build's products. It is set per line below
+# because the make that ships with macOS (3.81) silently ignores .SHELLFLAGS.
+SHELL := /bin/bash
+
 FIREBASE_VERSION = 11.15.0
 FIREBASE_ZIP_URL = https://github.com/firebase/firebase-ios-sdk/releases/download/$(FIREBASE_VERSION)/Firebase.zip
 
@@ -84,7 +90,7 @@ setup-project:
 
 build: setup-project
 	@echo "→ Building GodotFirebaseiOS for iOS Device..."
-	@xcodebuild -project $(ROOT_DIR)/GodotFirebaseiOS/GodotFirebaseiOS.xcodeproj \
+	@set -o pipefail; xcodebuild -project $(ROOT_DIR)/GodotFirebaseiOS/GodotFirebaseiOS.xcodeproj \
 		-scheme GodotFirebaseiOS \
 		-destination "generic/platform=iOS" \
 		-configuration Release \
@@ -95,7 +101,7 @@ build: setup-project
 		CODE_SIGNING_REQUIRED=NO \
 		| tail -20
 	@echo "→ Building GodotFirebaseiOS for iOS Simulator..."
-	@xcodebuild -project $(ROOT_DIR)/GodotFirebaseiOS/GodotFirebaseiOS.xcodeproj \
+	@set -o pipefail; xcodebuild -project $(ROOT_DIR)/GodotFirebaseiOS/GodotFirebaseiOS.xcodeproj \
 		-scheme GodotFirebaseiOS \
 		-destination "generic/platform=iOS Simulator" \
 		-configuration Release \


### PR DESCRIPTION
## What

Fixes #46: `make build` pipes both xcodebuild invocations through `| tail -20`, and make only sees `tail`'s exit status, which is always 0. A failed xcodebuild therefore did not stop the recipe; the remaining steps packaged whatever was sitting in `Build/Products` from the last successful build and the target ended with `✓ Build and update complete`.

Fix: `SHELL := /bin/bash` plus `set -o pipefail;` on the two xcodebuild recipe lines, so the pipeline's exit status is the first failing command's, not the last's. Output is unchanged.

Why per line and not `.SHELLFLAGS`: I tried `.SHELLFLAGS := -o pipefail -c` first, and my negative test caught it doing nothing. The make that ships with macOS is GNU Make 3.81 (2006, frozen over licensing), and `.SHELLFLAGS` only exists from 3.82, so stock macOS make (including the CI runners') ignores the variable silently. The per-line `set -o pipefail` works on every make. There is a comment in the Makefile so this does not get simplified back later.

I also deliberately did not add `errexit`: the multi-line recipes (the setup-sdk block, the vendor repackage loop) were written against make's default per-line semantics, and changing those in the same PR felt like more risk than the issue calls for.

## How to test

- Positive path: `make setup && make build` succeeds and looks identical to before.
- Negative path (the exact failure from #46): run the build with a toolchain that cannot parse the pinned SwiftGodot manifest, e.g. an Xcode older than 26.4.1 while a `swift-tools-version: 6.3` checkout sits in the build cache. Before this change, make continued past the xcodebuild error and printed the ✓; with this change it stops at the "Building for iOS Device" step with xcodebuild's real error and a nonzero exit.
- Same for the missing-platform failure (fresh Xcode without the iOS platform installed): now a hard stop instead of a silent repackage.

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] `make setup && make build` succeeds locally
- [ ] The demo project still works for the affected feature (if applicable) — build tooling only, no plugin code changed
